### PR TITLE
change compute type for F16 wrapper around cublas GEMMEx

### DIFF
--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -129,7 +129,7 @@ cublasStatus_t gemm_bias(
       C,
       CUDA_R_16F,
       ldc,
-      CUBLAS_COMPUTE_16F,
+      CUBLAS_COMPUTE_32F,
       CUBLAS_GEMM_DEFAULT_TENSOR_OP);
 }
 


### PR DESCRIPTION
Change the compute type for the F16 wrapper around cublas GEMMEx. 

The original code had `CUDA_R_32F` but was changed to `CUBLAS_16F` inadvertently during the rocblas->hipblas changes in PyTorch. Hence, the bug was introduced. 

This change will allow the unit test for `test_fused_dense.py` to pass sucessfully. 

```
/opt/rocm/apex/apex/contrib/test/fused_dense# pytest -v 
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.9.19, pytest-7.3.2, pluggy-1.4.0 -- /opt/conda/envs/py_3.9/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/opt/rocm-6.1.0/apex/apex/contrib/test/fused_dense/.hypothesis/examples')
rootdir: /opt/rocm-6.1.0/apex
plugins: xdist-3.3.1, xdoctest-1.1.0, hypothesis-5.35.1, flakefinder-1.1.0, rerunfailures-14.0, shard-0.1.2, cpp-2.3.0
collected 1 item                                                                                                                                                                 
Running 1 items in this shard: apex/contrib/test/fused_dense/test_fused_dense.py::FusedDenseTest::test_fused_dense

test_fused_dense.py::FusedDenseTest::test_fused_dense PASSED                                                                                                               [100%]
=============================================================================== 1 passed in 6.83s ================================================================================

```