### PR TITLE
setup: check if torch.cuda is available before calling cuda prop

### DIFF
--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -30,7 +30,6 @@
             __FILE__,                         \
             __LINE__);                        \
     exit(EXIT_FAILURE);                       \
-
   }
 #endif
 

--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -400,7 +400,7 @@ at::Tensor linear_bias_forward(at::Tensor input, at::Tensor weight, at::Tensor b
 
 #else 
   DISPATCH_TYPES(input.scalar_type(), "linear_bias_forward", [&] {
-    auto result = gemm_bias<compute_t, compute_datatype_t, scalar_t, datatype_t>(
+    auto result = gemm_bias<compute_t, scalar_t, datatype_t>(
                             HIPBLAS_OP_T, HIPBLAS_OP_N, out_features, batch_size, in_features, 
                             &alpha, &beta, weight.data_ptr<scalar_t>(), input.data_ptr<scalar_t>(), output.data_ptr<scalar_t>());
     if (result != 0) { fprintf(stderr, "INVALID RESULT for linear_bias_forward\n"); }
@@ -451,15 +451,15 @@ std::vector<at::Tensor> linear_bias_backward(at::Tensor input, at::Tensor weight
 #else
 
   DISPATCH_TYPES(input.scalar_type(), "linear_bias_forward", [&] {
-    auto result = gemm_bias<compute_t, compute_datatype_t, scalar_t, datatype_t>(
+    auto result = gemm_bias<compute_t, scalar_t, datatype_t>(
                             HIPBLAS_OP_N, HIPBLAS_OP_T, in_features, out_features, batch_size, 
                             &alpha, &beta, input.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), grad_weight.data_ptr<scalar_t>());
     if (result != 0) { fprintf(stderr, "INVALID RESULT for linear_bias_forward\n"); }
   });
 
     DISPATCH_TYPES(input.scalar_type(), "linear_bias_forward", [&] {
-    auto result = gemm_bias<compute_t, compute_datatype_t, scalar_t, datatype_t>(
-                            HIPBLAS_OP_N, HIPBLAS_OP_N, in_features, batch_size,, out_features,
+    auto result = gemm_bias<compute_t, scalar_t, datatype_t>(
+                            HIPBLAS_OP_N, HIPBLAS_OP_N, in_features, batch_size, out_features,
                             &alpha, &beta, weight.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), grad_input.data_ptr<scalar_t>());
     if (result != 0) { fprintf(stderr, "INVALID RESULT for linear_bias_forward\n"); }
   });

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ torch_dir = torch.__path__[0]
 
 def hipBLASlt_supported():
     supported_arch = ['gfx942']
+    arch_param = os.environ.get("PYTORCH_ROCM_ARCH", None)
+    if arch_param in supported_arch:
+        return True
     #torch.cuda.get_device_properties might fail if env does not have visible GPUs.
     if torch.cuda.is_available():
         device_props = torch.cuda.get_device_properties(0);
@@ -165,6 +168,7 @@ def check_if_rocm_pytorch():
 
 IS_ROCM_PYTORCH = check_if_rocm_pytorch()
 IS_HIPBLASLT_SUPPORTED = hipBLASlt_supported()
+print(f"INFO: IS_HIPBLASLT_SUPPORTED value is {IS_HIPBLASLT_SUPPORTED}")
 
 if not torch.cuda.is_available() and not IS_ROCM_PYTORCH:
     # https://github.com/NVIDIA/apex/issues/486

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,12 @@ torch_dir = torch.__path__[0]
 
 def hipBLASlt_supported():
     supported_arch = ['gfx942']
-    device_props = torch.cuda.get_device_properties(0); 
-    if device_props.gcnArchName.split(":",1)[0] in supported_arch: 
-        return True
-    else:
-        return False
+    #torch.cuda.get_device_properties might fail if env does not have visible GPUs.
+    if torch.cuda.is_available():
+        device_props = torch.cuda.get_device_properties(0);
+        if device_props.gcnArchName.split(":",1)[0] in supported_arch:
+            return True
+    return False
 
 # https://github.com/pytorch/pytorch/pull/71881
 # For the extensions which have rocblas_gemm_flags_fp16_alt_impl we need to make sure if at::BackwardPassGuard exists.


### PR DESCRIPTION
In hipBLASlt_supported(), torch.cuda.get_device_properties is called in an env where visiable GPUs are not present. This will return an error "RuntimeError: No HIP GPUs are available" and the build stops. Check if torch.cuda is available and then access torch.cuda properties.
Also fix build errors.