### PR TITLE
Fix: Gives 'self' error when pipe.enable_model_cpu_offload() is removed

### DIFF
--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -24,7 +24,7 @@ def manual_rms_norm(input, normalized_shape, weight, eps):
 
     # convert into half-precision if necessary
     if weight.dtype in [torch.float16, torch.bfloat16]:
-        input = input.to(self.weight.dtype)
+        input = input.to(weight.dtype)
 
     return weight * input
 


### PR DESCRIPTION
When pipe.enable_model_cpu_offload() is removed while in Flux inference.
It gives error that "self" is not defined.
Nvidia's version of apex already has this fixed.