### PR TITLE
Overriding base test class: do not auto destroy PG upon exit.

### DIFF
--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -48,6 +48,11 @@ class DistributedTestBase(common_distributed.MultiProcessTestCase):
     def init_method(self):
         return f"{common_utils.FILE_SCHEMA}{self.file_name}"
 
+    @property
+    def destroy_pg_upon_exit(self) -> bool:
+        # Overriding base test class: do not auto destroy PG upon exit.
+        return False
+
     @classmethod
     def _run(cls, rank, test_name, file_name, pipe):
         self = cls(test_name)


### PR DESCRIPTION
Overriding base test class: do not auto destroy PG upon exit.

affects test cases which have parallel test related to transformer