### PR TITLE
Fix setup

### DIFF
--- a/apex/transformer/tensor_parallel/layers.py
+++ b/apex/transformer/tensor_parallel/layers.py
@@ -401,7 +401,7 @@ def linear_with_grad_accumulation_and_async_allreduce(
         sequence_parallel_enabled,
         False,  # use_16bit_in_wgrad_accum_fusion
     )
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda',enabled=False):
         return LinearWithGradAccumulationAndAsyncCommunication.apply(*args)
 
 
@@ -422,7 +422,7 @@ def linear_with_grad_accumulation_and_async_allreduce_in16bit(
         sequence_parallel_enabled,
         True,  # use_16bit_in_wgrad_accum_fusion
     )
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda',enabled=False):
         return LinearWithGradAccumulationAndAsyncCommunication.apply(*args)
 
 

--- a/tests/L0/run_transformer/test_layers.py
+++ b/tests/L0/run_transformer/test_layers.py
@@ -398,6 +398,8 @@ class TensorParallelLayerTestBase:
                             chunks=tensor_model_parallel_world_size,
                             dim=0,
                         )[parallel_state.get_tensor_model_parallel_rank()],
+                        atol=1e-4,
+                        rtol=1e-3 
                     )
 
                 parallel_state.destroy_model_parallel()


### PR DESCRIPTION
Reduced the tolerance of UT to -4, Auto initilize the maxthreads from hip property, Fix Deprecated warning 

* Changed the setup.py to read the Environment variable PYTORCH_ROCM_ARCH instead of reading the rocminfo, Also read the maxThreadPerBlock from the HIP property

* Added get device Properly for Forward Function

* replacing hip functions with cu

fix issue : https://github.com/ROCm/apex/issues/175