### PR TITLE
Fixed the unit test of fused dense 

### DIFF
--- a/apex/contrib/test/fused_dense/test_fused_dense.py
+++ b/apex/contrib/test/fused_dense/test_fused_dense.py
@@ -15,7 +15,7 @@ class FusedDenseTest(unittest.TestCase):
         self.hidden_dim   = 1024
 
         self.ref_inputs = torch.randn(self.sequences*self.seq_length, self.hidden_dim,
-                                      dtype=torch.float16, device=torch.device("cuda")).int().half().requires_grad_(True)
+                                      dtype=torch.float16, device=torch.device("cuda")).half().requires_grad_(True)
 
         self.tst_inputs = self.ref_inputs.clone().detach().requires_grad_(True)
         self.dense = fused_dense.FusedDense(1024, 3072)

--- a/csrc/fused_dense_cuda.cu
+++ b/csrc/fused_dense_cuda.cu
@@ -449,7 +449,7 @@ std::vector<at::Tensor> linear_bias_backward(at::Tensor input, at::Tensor weight
   // Gradient of Weights:
   // grad_weight[out_features,in_features] = input[batch_size, in_features](T)  * output[batch_size, out_features] 
   // **********************************************************************************
-    CHECK_HIPBLASLT_ERROR(gemm_lt(HIPBLAS_OP_N, HIPBLAS_OP_T, &alpha, &beta, output, input, grad_weight, grad_bias, dummy_gelu, true, false, false));
+    CHECK_HIPBLASLT_ERROR(gemm_lt(HIPBLAS_OP_N, HIPBLAS_OP_T, &alpha, &beta, input, output, grad_weight, grad_bias, dummy_gelu, true, false, false));
 
   // **********************************************************************************
   // ToDo: Check why HipBLASLt fail to get bgrad above so this step is not needed.


### PR DESCRIPTION
Fixed the unit test of fused dense by updating the parameters in the gemm_lt for calculating d_weight in the kernel code. Also removed the int() cast of the input tensor as the unit test works for half dtype (#180)

Reference https://ontrack-internal.amd.com/browse/SWDEV-472709 