### PR TITLE
for distributed fused adam, 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -938,7 +938,8 @@ if "--fused_conv_bias_relu" in sys.argv:
         )
 
 if "--nccl_allocator" in sys.argv or "--cuda_ext" in sys.argv:
-    sys.argv.remove("--nccl_allocator")
+    if "--nccl_allocator" in sys.argv:
+        sys.argv.remove("--nccl_allocator")
     raise_if_cuda_home_none("--nccl_allocator")
     _nccl_version_getter = load(
         name="_nccl_version_getter",


### PR DESCRIPTION
add condition to remove nccl_allocator only if it is mentioned explicitly