### PR TITLE
update condition for building nccl_allocator extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -937,36 +937,35 @@ if "--fused_conv_bias_relu" in sys.argv:
             )
         )
 
-#NCCL allocator is supported for apex 1.6 version only
-if TORCH_MAJOR == 2 and TORCH_MINOR == 6:
-    if "--nccl_allocator" in sys.argv or "--cuda_ext" in sys.argv:
-        if "--nccl_allocator" in sys.argv:
-            sys.argv.remove("--nccl_allocator")
-        raise_if_cuda_home_none("--nccl_allocator")
-        _nccl_version_getter = load(
-            name="_nccl_version_getter",
-            sources=["apex/contrib/csrc/nccl_p2p/nccl_version.cpp", "apex/contrib/csrc/nccl_p2p/nccl_version_check.cu"],
+
+if "--nccl_allocator" in sys.argv or "--cuda_ext" in sys.argv:
+    if "--nccl_allocator" in sys.argv:
+        sys.argv.remove("--nccl_allocator")
+    raise_if_cuda_home_none("--nccl_allocator")
+    _nccl_version_getter = load(
+        name="_nccl_version_getter",
+        sources=["apex/contrib/csrc/nccl_p2p/nccl_version.cpp", "apex/contrib/csrc/nccl_p2p/nccl_version_check.cu"],
+    )
+    ccl_library = ["nccl"]
+    if IS_ROCM_PYTORCH:
+        ccl_library = ["rccl"]
+    _available_nccl_version = _nccl_version_getter.get_nccl_version()
+    if _available_nccl_version >= (2, 19):
+        ext_modules.append(
+            CUDAExtension(
+                name="_apex_nccl_allocator",
+                sources=[
+                    "apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp",
+                ],
+                include_dirs=[os.path.join(this_dir, "apex/apex/contrib/csrc/nccl_allocator")],
+                libraries=ccl_library,
+                extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
+            )
         )
-        ccl_library = ["nccl"]
-        if IS_ROCM_PYTORCH:
-            ccl_library = ["rccl"]
-        _available_nccl_version = _nccl_version_getter.get_nccl_version()
-        if _available_nccl_version >= (2, 19):
-            ext_modules.append(
-                CUDAExtension(
-                    name="_apex_nccl_allocator",
-                    sources=[
-                        "apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp",
-                    ],
-                    include_dirs=[os.path.join(this_dir, "apex/apex/contrib/csrc/nccl_allocator")],
-                    libraries=ccl_library,
-                    extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
-                )
-            )
-        else:
-            warnings.warn(
-                f"Skip `--nccl_allocator` as it requires NCCL 2.19 or later, but {_available_nccl_version[0]}.{_available_nccl_version[1]}"
-            )
+    else:
+        warnings.warn(
+            f"Skip `--nccl_allocator` as it requires NCCL 2.19 or later, but {_available_nccl_version[0]}.{_available_nccl_version[1]}"
+        )
 
 
 


### PR DESCRIPTION
Remove the condition of pytorch equal to 2.6 for building the NCCL allocator in release/1.7 branch
