### PR TITLE
upgrade matplotlib to resolve setuptools_scm error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy
 PyYAML>=5.1
 pytest>=3.5.1
 packaging>=14.0
-matplotlib==3.5.1
+matplotlib>=3.8


### PR DESCRIPTION
The error:
File "/tmp/easy_install-_pfhn8pn/matplotlib-3.5.1/.eggs/setuptools_scm-8.3.1-py3.12.egg/setuptools_scm/_integration/pyproject_reading.py", line 36, in read_pyproject section = defn.get("tool", {})[tool_name] ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^ KeyError: 'setuptools_scm'

Solution : https://github.com/matplotlib/matplotlib/blob/v3.8.x/pyproject.toml#L22 matplotlib 3.8 is th e first version to have pyproject.toml with this tool.setuptools_scm section. This higher version of setuptools expects this structure in the Python packages it installs. Matplotlib 3.5.1 doesn't satisfy this condition. The solution is to change the condition to matplotlib>=3.8.