### PR TITLE
Update fused layer norm code from upstream apex repo. 

### DIFF
--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -5,11 +5,17 @@ import torch
 from torch.nn.parameter import Parameter
 from torch.nn import init
 from torch.nn import functional as F
+from typing import List, Tuple
 
 from apex._autocast_utils import _cast_if_autocast_enabled
 
 global fused_layer_norm_cuda
 fused_layer_norm_cuda = None
+
+
+# PyTorch supports `torch.library.custom_op` since 2.4.0.
+def supports_custom_op() -> bool:
+    return hasattr(torch.library, "custom_op")
 
 
 # Reference implementation from Huggingface
@@ -24,180 +30,682 @@ def manual_rms_norm(input, normalized_shape, weight, eps):
 
     # convert into half-precision if necessary
     if weight.dtype in [torch.float16, torch.bfloat16]:
-        input = input.to(self.weight.dtype)
+        input = input.to(weight.dtype)
 
     return weight * input
 
 
 class FusedLayerNormAffineFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, weight, bias, normalized_shape, eps):
+    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         bias_ = bias.contiguous()
         output, mean, invvar = fused_layer_norm_cuda.forward_affine(
             input_, ctx.normalized_shape, weight_, bias_, ctx.eps
         )
-        ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, bias_, None, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        input_, weight_, bias_, mean, invvar = ctx.saved_tensors
+        input_or_output, weight_, bias_, mean, invvar = ctx.saved_tensors
         grad_input = grad_weight = grad_bias = None
         grad_input, grad_weight, grad_bias = fused_layer_norm_cuda.backward_affine(
-            grad_output.contiguous(), mean, invvar, input_, ctx.normalized_shape, weight_, bias_, ctx.eps
+            grad_output.contiguous(), mean, invvar, input_or_output,
+            ctx.normalized_shape, weight_, bias_, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, grad_weight, grad_bias, None, None
+        return grad_input, grad_weight, grad_bias, None, None, None
+
+
+if supports_custom_op():
+
+    @torch.library.custom_op("apex::fused_layer_norm_affine_fwd", mutates_args=())
+    def fused_layer_norm_affine_fwd(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        global fused_layer_norm_cuda
+        if fused_layer_norm_cuda is None:
+            fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
+
+        input_ = input.contiguous()
+        weight_ = weight.contiguous()
+        bias_ = bias.contiguous()
+        output, mean, invvar = fused_layer_norm_cuda.forward_affine(
+            input_, normalized_shape, weight_, bias_, eps
+        )
+        return output, mean, invvar
+
+    @fused_layer_norm_affine_fwd.register_fake
+    def fused_layer_norm_affine_fwd_fake(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        input = input.contiguous()
+        weight = weight.contiguous()
+        bias = bias.contiguous()
+        idiff = input.ndim - len(normalized_shape)
+        n = 1
+        for i in range(idiff):
+            n *= input.shape[i]
+        if input.dtype in [torch.float16, torch.bfloat16]:
+            dtype = torch.float32
+        else:
+            dtype = input.dtype
+        mean = torch.empty([n], dtype=dtype, device=input.device)
+        invvar = torch.empty_like(mean)
+        return torch.empty_like(input), mean, invvar
+
+    @torch.library.custom_op("apex::fused_layer_norm_affine_bwd", mutates_args=())
+    def fused_layer_norm_affine_bwd(
+        grad_output: torch.Tensor,
+        mean: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        grad_input, grad_weight, grad_bias = fused_layer_norm_cuda.backward_affine(
+            grad_output.contiguous(),
+            mean,
+            invvar,
+            input_or_output,
+            normalized_shape,
+            weight,
+            bias,
+            eps,
+            memory_efficient,
+        )
+        return grad_input, grad_weight, grad_bias
+
+    @fused_layer_norm_affine_bwd.register_fake
+    def fused_layer_norm_affine_bwd_fake(
+        grad_output: torch.Tensor,
+        mean: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        grad_input = torch.empty_like(input_or_output)
+        grad_weight = torch.empty_like(weight)
+        grad_bias = torch.empty_like(bias)
+        return grad_input, grad_weight, grad_bias
+
+    def _fused_layer_norm_affine_backward(ctx, grad_output, grad_mean, grad_invvar):
+        input_or_output, weight_, bias_, mean, invvar = ctx.saved_tensors
+        grad_input = grad_weight = grad_bias = None
+        grad_input, grad_weight, grad_bias = fused_layer_norm_affine_bwd(
+            grad_output,
+            mean,
+            invvar,
+            input_or_output,
+            ctx.normalized_shape,
+            weight_,
+            bias_,
+            ctx.eps,
+            ctx.memory_efficient,
+        )
+        return grad_input, grad_weight, grad_bias, None, None, None
+
+    def _fused_layer_norm_affine_setup_context(ctx, inputs, output):
+        input, weight, bias, normalized_shape, eps, memory_efficient = inputs
+        output, mean, invvar = output
+        input_ = input.contiguous()
+        weight_ = weight.contiguous()
+        bias_ = bias.contiguous()
+        if memory_efficient:
+            ctx.save_for_backward(output, weight_, bias_, None, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
+        ctx.normalized_shape = normalized_shape
+        ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
+
+    fused_layer_norm_affine_fwd.register_autograd(
+        _fused_layer_norm_affine_backward,
+        setup_context=_fused_layer_norm_affine_setup_context,
+    )
 
 
 class FusedRMSNormAffineFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, weight, normalized_shape, eps):
+    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         output, invvar = fused_layer_norm_cuda.rms_forward_affine(
             input_, ctx.normalized_shape, weight_, ctx.eps)
-        ctx.save_for_backward(input_, weight_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        input_, weight_, invvar = ctx.saved_tensors
+        input_or_output, weight_, invvar = ctx.saved_tensors
         grad_input = grad_weight = None
         grad_input, grad_weight = fused_layer_norm_cuda.rms_backward_affine(
-           grad_output.contiguous(), invvar, input_, ctx.normalized_shape, weight_, ctx.eps
+           grad_output.contiguous(), invvar, input_or_output,
+           ctx.normalized_shape, weight_, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, grad_weight, None, None
+        return grad_input, grad_weight, None, None, None
+
+if supports_custom_op():
+    @torch.library.custom_op("apex::fused_rms_norm_affine_fwd", mutates_args=())
+    def fused_rms_norm_affine_fwd(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        global fused_layer_norm_cuda
+        if fused_layer_norm_cuda is None:
+            fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
+
+        input_ = input.contiguous()
+        weight_ = weight.contiguous()
+        output, invvar = fused_layer_norm_cuda.rms_forward_affine(
+            input_, normalized_shape, weight_, eps
+        )
+        return output, invvar
+
+
+    @fused_rms_norm_affine_fwd.register_fake
+    def fused_rms_norm_affine_fwd_fake(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        input = input.contiguous()
+        weight = weight.contiguous()
+        idiff = input.ndim - len(normalized_shape)
+        n = 1
+        for i in range(idiff):
+            n *= input.shape[i]
+        if input.dtype in [torch.float16, torch.bfloat16]:
+            dtype = torch.float32
+        else:
+            dtype = input.dtype
+        return (
+            torch.empty_like(input),
+            torch.empty(
+                [n],
+                dtype=dtype,
+                device=input.device,
+                requires_grad=input.requires_grad,
+                memory_format=torch.contiguous_format,
+            ),
+        )
+
+
+    @torch.library.custom_op("apex::fused_rms_norm_affine_bwd", mutates_args=())
+    def fused_rms_norm_affine_bwd(
+        grad_output: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        weight: torch.Tensor,
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        grad_input, grad_weight = fused_layer_norm_cuda.rms_backward_affine(
+            grad_output.contiguous(),
+            invvar,
+            input_or_output,
+            normalized_shape,
+            weight,
+            eps,
+            memory_efficient,
+        )
+        return grad_input, grad_weight
+
+
+    @fused_rms_norm_affine_bwd.register_fake
+    def fused_rms_norm_affine_bwd_fake(
+        grad_output: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        weight: torch.Tensor,
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        grad_input = torch.empty_like(input_or_output)
+        grad_weight = torch.empty_like(weight)
+        return grad_input, grad_weight
+
+
+    def _fused_rms_norm_affine_backward(ctx, grad_output, grad_invvar):
+        input_or_output, weight_, invvar = ctx.saved_tensors
+        grad_input = grad_weight = None
+        grad_input, grad_weight = fused_rms_norm_affine_bwd(
+            grad_output,
+            invvar,
+            input_or_output,
+            ctx.normalized_shape,
+            weight_,
+            ctx.eps,
+            ctx.memory_efficient,
+        )
+        return grad_input, grad_weight, None, None, None
+
+
+    def _fused_rms_norm_affine_setup_context(ctx, inputs, output):
+        input_, weight_, normalized_shape, eps, memory_efficient = inputs
+        output_, invvar = output
+        input_ = input_.contiguous()
+        weight_ = weight_.contiguous()
+        if memory_efficient:
+            ctx.save_for_backward(output_, weight_, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, invvar)
+        ctx.normalized_shape = normalized_shape
+        ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
+
+
+    fused_rms_norm_affine_fwd.register_autograd(
+        _fused_rms_norm_affine_backward,
+        setup_context=_fused_rms_norm_affine_setup_context
+    )
 
 
 class FusedLayerNormAffineMixedDtypesFunction(FusedLayerNormAffineFunction):
 
     @staticmethod
-    def forward(ctx, input, weight, bias, normalized_shape, eps):
+    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         bias_ = bias.contiguous()
         output, mean, invvar = fused_layer_norm_cuda.forward_affine_mixed_dtypes(
             input_, ctx.normalized_shape, weight_, bias_, ctx.eps
         )
-        ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, bias_, None, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
         return output
 
 
 class FusedRMSNormAffineMixedDtypesFunction(FusedRMSNormAffineFunction):
 
     @staticmethod
-    def forward(ctx, input, weight, normalized_shape, eps):
+    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         output, invvar = fused_layer_norm_cuda.rms_forward_affine_mixed_dtypes(
             input_, ctx.normalized_shape, weight_, ctx.eps
         )
-
-        ctx.save_for_backward(input_, weight_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, invvar)
         return output
 
 
 class FusedLayerNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, normalized_shape, eps):
+    def forward(ctx, input, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         output, mean, invvar = fused_layer_norm_cuda.forward(input_, ctx.normalized_shape, ctx.eps)
-        ctx.save_for_backward(input_, mean, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, None, invvar)
+        else:
+            ctx.save_for_backward(input_, mean, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        input_, mean, invvar = ctx.saved_tensors
-        grad_input = None
+        input_or_output, mean, invvar = ctx.saved_tensors
         grad_input = fused_layer_norm_cuda.backward(
-            grad_output.contiguous(), mean, invvar, input_, ctx.normalized_shape, ctx.eps
+            grad_output.contiguous(), mean, invvar, input_or_output,
+            ctx.normalized_shape, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, None, None
+        return grad_input, None, None, None
+
+
+if supports_custom_op():
+
+    @torch.library.custom_op("apex::fused_layer_norm_fwd", mutates_args=())
+    def fused_layer_norm_fwd(
+        input: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        global fused_layer_norm_cuda
+        if fused_layer_norm_cuda is None:
+            fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
+
+        input_ = input.contiguous()
+        output, mean, invvar = fused_layer_norm_cuda.forward(
+            input_, normalized_shape, eps
+        )
+        return output, mean, invvar
+
+    @fused_layer_norm_fwd.register_fake
+    def fused_layer_norm_fwd_fake(
+        input: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        input = input.contiguous()
+        idiff = input.ndim - len(normalized_shape)
+        n = 1
+        for i in range(idiff):
+            n *= input.shape[i]
+        if input.dtype in [torch.float16, torch.bfloat16]:
+            dtype = torch.float32
+        else:
+            dtype = input.dtype
+        mean = torch.empty([n], dtype=dtype, device=input.device)
+        invvar = torch.empty_like(mean)
+        return torch.empty_like(input), mean, invvar
+
+    @torch.library.custom_op("apex::fused_layer_norm_bwd", mutates_args=())
+    def fused_layer_norm_bwd(
+        grad_output: torch.Tensor,
+        mean: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> torch.Tensor:
+        grad_input = fused_layer_norm_cuda.backward(
+            grad_output.contiguous(),
+            mean,
+            invvar,
+            input_or_output,
+            normalized_shape,
+            eps,
+            memory_efficient,
+        )
+        return grad_input
+
+    @fused_layer_norm_bwd.register_fake
+    def fused_layer_norm_bwd_fake(
+        grad_output: torch.Tensor,
+        mean: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> torch.Tensor:
+        grad_input = torch.empty_like(input_or_output)
+        return grad_input
+
+    def _fused_layer_norm_backward(ctx, grad_output, grad_mean, grad_invvar):
+        input_or_output, mean, invvar = ctx.saved_tensors
+        grad_input = fused_layer_norm_bwd(
+            grad_output,
+            mean,
+            invvar,
+            input_or_output,
+            ctx.normalized_shape,
+            ctx.eps,
+            ctx.memory_efficient,
+        )
+        return grad_input, None, None, None
+
+    def _fused_layer_norm_setup_context(ctx, inputs, output):
+        input, normalized_shape, eps, memory_efficient = inputs
+        output, mean, invvar = output
+        input_ = input.contiguous()
+        if memory_efficient:
+            ctx.save_for_backward(output, None, invvar)
+        else:
+            ctx.save_for_backward(input_, mean, invvar)
+        ctx.normalized_shape = normalized_shape
+        ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
+
+    fused_layer_norm_fwd.register_autograd(
+        _fused_layer_norm_backward,
+        setup_context=_fused_layer_norm_setup_context,
+    )
 
 
 class FusedRMSNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, normalized_shape, eps):
+    def forward(ctx, input, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         output, invvar = fused_layer_norm_cuda.rms_forward(input_, ctx.normalized_shape, ctx.eps)
-        ctx.save_for_backward(input_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, invvar)
+        else:
+            ctx.save_for_backward(input_, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        input_, invvar = ctx.saved_tensors
+        input_or_output, invvar = ctx.saved_tensors
         grad_input = None
         grad_input = fused_layer_norm_cuda.rms_backward(
-            grad_output.contiguous(), invvar, input_, ctx.normalized_shape, ctx.eps
+            grad_output.contiguous(), invvar, input_or_output,
+            ctx.normalized_shape, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, None, None
+        return grad_input, None, None, None
 
 
-def fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps)
-    with torch.cuda.amp.autocast(enabled=False):
-        return FusedLayerNormAffineFunction.apply(*args)
+if supports_custom_op():
+    @torch.library.custom_op("apex::fused_rms_norm_fwd", mutates_args=())
+    def fused_rms_norm_fwd(
+        input: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        global fused_layer_norm_cuda
+        if fused_layer_norm_cuda is None:
+            fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
+
+        input_ = input.contiguous()
+        output, invvar = fused_layer_norm_cuda.rms_forward(
+            input_, normalized_shape, eps
+        )
+        return output, invvar
 
 
-def fused_layer_norm(input, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, normalized_shape, eps)
-    with torch.cuda.amp.autocast(enabled=False):
-        return FusedLayerNormFunction.apply(*args)
+    @fused_rms_norm_fwd.register_fake
+    def fused_rms_norm_fwd_fake(
+        input: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        input = input.contiguous()
+        idiff = input.ndim - len(normalized_shape)
+        n = 1
+        for i in range(idiff):
+            n *= input.shape[i]
+        if input.dtype in [torch.float16, torch.bfloat16]:
+            dtype = torch.float32
+        else:
+            dtype = input.dtype
+        return (
+            torch.empty_like(input),
+            torch.empty(
+                [n],
+                dtype=dtype,
+                device=input.device,
+                requires_grad=input.requires_grad,
+                memory_format=torch.contiguous_format,
+            ),
+        )
 
 
-def mixed_dtype_fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps)
-    with torch.cuda.amp.autocast(enabled=False):
+    @torch.library.custom_op("apex::fused_rms_norm_bwd", mutates_args=())
+    def fused_rms_norm_bwd(
+        grad_output: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> torch.Tensor:
+        grad_input = fused_layer_norm_cuda.rms_backward(
+            grad_output.contiguous(),
+            invvar,
+            input_or_output,
+            normalized_shape,
+            eps,
+            memory_efficient,
+        )
+        return grad_input
+
+
+    @fused_rms_norm_bwd.register_fake
+    def fused_rms_norm_bwd_fake(
+        grad_output: torch.Tensor,
+        invvar: torch.Tensor,
+        input_or_output: torch.Tensor,
+        normalized_shape: List[int],
+        eps: float,
+        memory_efficient: bool = False,
+    ) -> torch.Tensor:
+        grad_input = torch.empty_like(input_or_output)
+        return grad_input
+
+
+    def _fused_rms_norm_backward(ctx, grad_output, grad_invvar):
+        input_or_output, invvar = ctx.saved_tensors
+        grad_input = None
+        grad_input = fused_rms_norm_bwd(
+            grad_output,
+            invvar,
+            input_or_output,
+            ctx.normalized_shape,
+            ctx.eps,
+            ctx.memory_efficient,
+        )
+        return grad_input, None, None, None
+
+
+    def _fused_rms_norm_setup_context(ctx, inputs, output):
+        input_, normalized_shape, eps, memory_efficient = inputs
+        output_, invvar = output
+        input_ = input_.contiguous()
+        if memory_efficient:
+            ctx.save_for_backward(output_, invvar)
+        else:
+            ctx.save_for_backward(input_, invvar)
+        ctx.normalized_shape = normalized_shape
+        ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
+
+
+    fused_rms_norm_fwd.register_autograd(
+        _fused_rms_norm_backward,
+        setup_context=_fused_rms_norm_setup_context
+    )
+
+
+def fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps, memory_efficient)
+    with torch.amp.autocast('cuda', enabled=False):
+        if supports_custom_op():
+            return fused_layer_norm_affine_fwd(*args)[0]
+        else:
+            return FusedLayerNormAffineFunction.apply(*args)
+
+
+def fused_layer_norm(input, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, normalized_shape, eps, memory_efficient)
+    with torch.amp.autocast('cuda', enabled=False):
+        if supports_custom_op():
+            return fused_layer_norm_fwd(*args)[0]
+        else:
+            return FusedLayerNormFunction.apply(*args)
+
+
+def mixed_dtype_fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps, memory_efficient)
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedLayerNormAffineMixedDtypesFunction.apply(*args)
 
 
-def fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps)
-    with torch.cuda.amp.autocast(enabled=False):
-        return FusedRMSNormAffineFunction.apply(*args)
+def fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps, memory_efficient)
+    with torch.amp.autocast('cuda', enabled=False):
+        if supports_custom_op():
+            return fused_rms_norm_affine_fwd(*args)[0]
+        else:
+            return FusedRMSNormAffineFunction.apply(*args)
 
 
-def fused_rms_norm(input, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, normalized_shape, eps)
-    with torch.cuda.amp.autocast(enabled=False):
-        return FusedRMSNormFunction.apply(*args)
+def fused_rms_norm(input, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, normalized_shape, eps, memory_efficient)
+    with torch.amp.autocast('cuda', enabled=False):
+        if supports_custom_op():
+            return fused_rms_norm_fwd(*args)[0]
+        else:
+            return FusedRMSNormFunction.apply(*args)
 
 
-def mixed_dtype_fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps)
-    with torch.cuda.amp.autocast(enabled=False):
+def mixed_dtype_fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps, memory_efficient)
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedRMSNormAffineMixedDtypesFunction.apply(*args)
 
 
@@ -261,7 +769,7 @@ class FusedLayerNorm(torch.nn.Module):
     .. _`Layer Normalization`: https://arxiv.org/abs/1607.06450
     """
 
-    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True):
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, memory_efficient=False):
         super().__init__()
 
         global fused_layer_norm_cuda
@@ -272,6 +780,7 @@ class FusedLayerNorm(torch.nn.Module):
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
         self.elementwise_affine = elementwise_affine
+        self.memory_efficient = memory_efficient
         if self.elementwise_affine:
             self.weight = Parameter(torch.empty(*normalized_shape))
             self.bias = Parameter(torch.empty(*normalized_shape))
@@ -286,12 +795,14 @@ class FusedLayerNorm(torch.nn.Module):
             init.zeros_(self.bias)
 
     def forward(self, input):
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or torch.compiler.is_compiling() or not input.is_cuda:
             return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         if self.elementwise_affine:
-            return fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
+            return fused_layer_norm_affine(
+                input, self.weight, self.bias, self.normalized_shape, self.eps, self.memory_efficient
+            )
         else:
-            return fused_layer_norm(input, self.normalized_shape, self.eps)
+            return fused_layer_norm(input, self.normalized_shape, self.eps, self.memory_efficient)
 
     def extra_repr(self):
         return "{normalized_shape}, eps={eps}, " "elementwise_affine={elementwise_affine}".format(**self.__dict__)
@@ -357,7 +868,7 @@ class FusedRMSNorm(torch.nn.Module):
     .. _`Root Mean Square Layer Normalization`: https://arxiv.org/pdf/1910.07467.pdf
     """
 
-    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True):
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, memory_efficient=False):
         super().__init__()
 
         global fused_layer_norm_cuda
@@ -368,6 +879,7 @@ class FusedRMSNorm(torch.nn.Module):
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
         self.elementwise_affine = elementwise_affine
+        self.memory_efficient = memory_efficient
         if self.elementwise_affine:
             self.weight = Parameter(torch.empty(*normalized_shape))
         else:
@@ -379,13 +891,15 @@ class FusedRMSNorm(torch.nn.Module):
             init.ones_(self.weight)
 
     def forward(self, input):
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or torch.compiler.is_compiling() or not input.is_cuda:
             return manual_rms_norm(input, self.normalized_shape, self.weight, self.eps)
 
         if self.elementwise_affine:
-            return fused_rms_norm_affine(input, self.weight, self.normalized_shape, self.eps)
+            return fused_rms_norm_affine(
+                input, self.weight, self.normalized_shape, self.eps, self.memory_efficient
+            )
         else:
-            return fused_rms_norm(input, self.normalized_shape, self.eps)
+            return fused_rms_norm(input, self.normalized_shape, self.eps, self.memory_efficient)
 
     def extra_repr(self):
         return "{normalized_shape}, eps={eps}, " "elementwise_affine={elementwise_affine}".format(**self.__dict__)
@@ -397,7 +911,7 @@ class FusedRMSNorm(torch.nn.Module):
 # See: `layer_norm_affine` and `layer_norm_affine_mixed_dtypes` in "csrc/layer_norm_cuda.cpp"
 class MixedFusedLayerNorm(FusedLayerNorm):
 
-    def __init__(self, normalized_shape, eps=1e-5, **kwargs):
+    def __init__(self, normalized_shape, eps=1e-5, *, memory_efficient=False, **kwargs):
         if "elementwise_affine" in kwargs:
             import warnings
             warnings.warn("MixedFusedLayerNorm does not support `elementwise_affine` argument")
@@ -405,13 +919,16 @@ class MixedFusedLayerNorm(FusedLayerNorm):
             if not elementwise_affine:
                 raise RuntimeError("MixedFusedLayerNorm does not support `elementwise_affine = False`")
 
-        super().__init__(normalized_shape=normalized_shape, eps=eps, elementwise_affine=True)
-
+        super().__init__(
+            normalized_shape=normalized_shape, eps=eps, elementwise_affine=True, memory_efficient=memory_efficient
+        )
     def forward(self, input: torch.Tensor):
         # NOTE (mkozuki): CPU path is here mainly for unittest sake.
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
-        return mixed_dtype_fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
+        return mixed_dtype_fused_layer_norm_affine(
+            input, self.weight, self.bias, self.normalized_shape, self.eps, self.memory_efficient
+        )
 
 
 # MixedFusedLayerNorm differs from FusedLayerNorm in that this layer norm uses parameter's dtype
@@ -419,7 +936,7 @@ class MixedFusedLayerNorm(FusedLayerNorm):
 # See: `layer_norm_affine` and `layer_norm_affine_mixed_dtypes` in "csrc/layer_norm_cuda.cpp"
 class MixedFusedRMSNorm(FusedRMSNorm):
 
-    def __init__(self, normalized_shape, eps=1e-5, **kwargs):
+    def __init__(self, normalized_shape, eps=1e-5, *, memory_efficient=False, **kwargs):
         if "elementwise_affine" in kwargs:
             import warnings
             warnings.warn("MixedFusedRMSNorm does not support `elementwise_affine` argument")
@@ -427,11 +944,14 @@ class MixedFusedRMSNorm(FusedRMSNorm):
             if not elementwise_affine:
                 raise RuntimeError("MixedFusedRMSNorm does not support `elementwise_affine = False`")
 
-        super().__init__(normalized_shape=normalized_shape, eps=eps, elementwise_affine=True)
-
+        super().__init__(
+            normalized_shape=normalized_shape, eps=eps, elementwise_affine=True, memory_efficient=memory_efficient
+        )
     def forward(self, input: torch.Tensor):
         # NOTE (mkozuki): CPU path is here mainly for unittest sake.
         # TODO Manual RMS Norm Implementation Here
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return manual_rms_norm(input, self.normalized_shape, self.weight, self.eps)
-        return mixed_dtype_fused_rms_norm_affine(input, self.weight, self.normalized_shape, self.eps)
+        return mixed_dtype_fused_rms_norm_affine(
+            input, self.weight, self.normalized_shape, self.eps, self.memory_efficient
+        )

--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -7,7 +7,7 @@
 #include <cuda_runtime.h>
 
 #include "type_shim.h"
-
+#include "static_switch.h"
 
 template<typename U> __device__
 void cuWelfordOnlineSum(
@@ -74,7 +74,7 @@ void cuWelfordMuSigma2(
   const int i1,
   U& mu,
   U& sigma2,
-  U* buf,
+  U* buf,  
   const int GPU_WARP_SIZE,
   bool rms_only)
 {
@@ -87,6 +87,7 @@ void cuWelfordMuSigma2(
   U count = U(0);
   mu= U(0);
   sigma2 = U(0);
+
   if (i1 < n1) {
     // one warp normalizes one n1 index,
     // synchronization is implicit
@@ -105,6 +106,9 @@ void cuWelfordMuSigma2(
         }
       }
     }
+
+    
+
     for (;  l < n2;  ++l) {
       U curr = static_cast<U>(lvals[l]);
       if (!rms_only) {
@@ -113,16 +117,31 @@ void cuWelfordMuSigma2(
        cuRMSOnlineSum<U>(curr, sigma2);
       }
     }
+
     // intra-warp reductions
-    #pragma unroll
-    for (int stride = GPU_WARP_SIZE / 2; stride > 0; stride /= 2) {  
-      U sigma2B = WARP_SHFL_DOWN(sigma2, stride);
-      if (!rms_only) {
-        U muB = WARP_SHFL_DOWN(mu, stride);
-        U countB = WARP_SHFL_DOWN(count, stride);  
-        cuChanOnlineSum<U>(muB, sigma2B, countB, mu, sigma2, count);
-      } else {
-        cuChanRMSOnlineSum<U>(sigma2B, sigma2);
+    if(USE_ROCM){
+      #pragma unroll
+      for (int stride = GPU_WARP_SIZE / 2; stride > 0; stride /= 2) {  
+        U sigma2B = WARP_SHFL_DOWN(sigma2, stride);
+        if (!rms_only) {
+          U muB = WARP_SHFL_DOWN(mu, stride);
+          U countB = WARP_SHFL_DOWN(count, stride);  
+          cuChanOnlineSum<U>(muB, sigma2B, countB, mu, sigma2, count);
+        } else {
+          cuChanRMSOnlineSum<U>(sigma2B, sigma2);
+        }
+      }
+    }else{
+      for (int l = 0;  l <= 4;  ++l) {
+        int srcLaneB = (threadIdx.x+(1<<l))&31;
+        U sigma2B = WARP_SHFL(sigma2, srcLaneB);
+        if (!rms_only) {
+          U muB = WARP_SHFL(mu, srcLaneB);
+          U countB = WARP_SHFL(count, srcLaneB);
+          cuChanOnlineSum<U>(muB,sigma2B,countB,mu,sigma2,count);
+        } else {
+          cuChanRMSOnlineSum<U>(sigma2B, sigma2);
+        }
       }
     }
     // threadIdx.x == 0 has correct values for each warp
@@ -241,15 +260,30 @@ void cuWelfordMuSigma2(
       }
     }
     // intra-warp reductions
-    #pragma unroll
-    for (int stride = GPU_WARP_SIZE / 2; stride > 0; stride /= 2) {
-      float sigma2B = WARP_SHFL_DOWN(sigma2, stride);
-      if (!rms_only) {
-        float muB = WARP_SHFL_DOWN(mu, stride);
-        float countB = WARP_SHFL_DOWN(count, stride);
-        cuChanOnlineSum(muB, sigma2B, countB, mu, sigma2, count);
-      } else {
-        cuChanRMSOnlineSum(sigma2B, sigma2);
+    if(USE_ROCM){
+      #pragma unroll
+      for (int stride = GPU_WARP_SIZE / 2; stride > 0; stride /= 2) {
+        float sigma2B = WARP_SHFL_DOWN(sigma2, stride);
+        if (!rms_only) {
+          float muB = WARP_SHFL_DOWN(mu, stride);
+          float countB = WARP_SHFL_DOWN(count, stride);
+          cuChanOnlineSum(muB, sigma2B, countB, mu, sigma2, count);
+        } else {
+          cuChanRMSOnlineSum(sigma2B, sigma2);
+        }
+      }
+    }
+    else{
+      for (int l = 0;  l <= 4;  ++l) {
+        int srcLaneB = (threadIdx.x+(1<<l))&31;
+        float sigma2B = WARP_SHFL(sigma2, srcLaneB);
+        if (!rms_only) {
+          float muB = WARP_SHFL(mu, srcLaneB);
+          float countB = WARP_SHFL(count, srcLaneB);
+          cuChanOnlineSum(muB,sigma2B,countB,mu,sigma2,count);
+        } else {
+          cuChanRMSOnlineSum(sigma2B, sigma2);
+        }
       }
     }
     // threadIdx.x == 0 has correct values for each warp
@@ -306,15 +340,13 @@ void cuWelfordMuSigma2(
 template<typename U> U rsqrt(U v) {
   return U(1) / sqrt(v);
 }
-#if defined USE_ROCM
-__device__ float rsqrt(float v) {
-  return rsqrtf(v);
-}
-#else
 template<> float rsqrt(float v) {
-  return rsqrtf(v);
+  #if defined (USE_ROCM)
+    return 1/sqrtf(v);
+  #else
+    return rsqrtf(v);
+  #endif
 }
-#endif
 template<> double rsqrt(double v) {
   return rsqrt(v);
 }
@@ -370,17 +402,19 @@ void cuApplyLayerNorm_(
   const V* __restrict__ gamma,
   const V* __restrict__ beta,
   const int GPU_WARP_SIZE,
-  bool rms_only)
+  bool rms_only
+  )
 {
   // Assumptions:
   // 1) blockDim.x == warpSize
   // 2) Tensors are contiguous
   //
-  for (int i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
+  for (auto i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
     SharedMemory<U> shared;
     U* buf = shared.getPointer();
     U mu,sigma2;
-    cuWelfordMuSigma2(vals,n1,n2,i1,mu,sigma2,buf, GPU_WARP_SIZE, rms_only);
+    cuWelfordMuSigma2(vals,n1,n2,i1,mu,sigma2,buf,GPU_WARP_SIZE,rms_only);
+
     const T* lvals = vals + i1*n2;
     V* ovals = output_vals + i1*n2;
     U c_invvar = rsqrt(sigma2 + epsilon);
@@ -427,7 +461,8 @@ void cuApplyLayerNorm(
   const U epsilon,
   const V* __restrict__ gamma,
   const V* __restrict__ beta,
-  const int warp_size)
+  const int warp_size
+  )
 {
   cuApplyLayerNorm_<T, U, V>(output_vals, mean, invvar, vals, n1, n2, epsilon, gamma, beta, warp_size, false);
 }
@@ -441,12 +476,34 @@ void cuApplyRMSNorm(
   const int n2,
   const U epsilon,
   const V* __restrict__ gamma,
-  const int warp_size)
+  const int warp_size
+  )
 {
   cuApplyLayerNorm_<T, U, V>(output_vals, NULL, invvar, vals, n1, n2, epsilon, gamma, NULL, warp_size, true);
 }
 
-template<typename T, typename U, typename V> __device__
+
+template<typename V> __device__
+V clamp_by_magnitude(V curr_gamma, double eps)
+{
+  const V kMinGamma = V(eps);
+  if (curr_gamma >= 0) {
+    if (curr_gamma < kMinGamma) {
+      return kMinGamma;
+    } else {
+      return curr_gamma;
+    }
+  } else {
+    if (curr_gamma > -kMinGamma) {
+      return -kMinGamma;
+    } else {
+      return curr_gamma;
+    }
+  }
+}
+
+
+template<typename T, typename U, typename V, bool MemoryEfficient> __device__
 void cuLoadWriteStridedInputs(
     const int i1_block,
     const int thr_load_row_off,
@@ -455,34 +512,41 @@ void cuLoadWriteStridedInputs(
     const int row_stride,
     U* warp_buf1,
     U* warp_buf2,
-    const T* input,
+    const T* input_or_output,
     const V* dout,
     const int i1_end,
     const int n2,
     const U* __restrict__ mean,
     const U* __restrict__ invvar,
+    const V* __restrict__ gamma,
+    const V* __restrict__ beta,
+    const double eps,
     bool rms_only
     )
 {
   int i1 = i1_block+thr_load_row_off;
   if (i1 < i1_end) {
-    U curr_mean;
-    if (!rms_only) {
-      curr_mean = mean[i1];
-    }
-    U curr_invvar = invvar[i1];
     for (int k = 0;  k < blockDim.y;  ++k) {
       int i2 = i2_off + k;
       int load_idx = i1*n2+i2;
       int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
       if (i2<n2) {
-        U curr_input = static_cast<U>(input[load_idx]);
+        U c_h = static_cast<U>(input_or_output[load_idx]);
         U curr_dout = static_cast<U>(dout[load_idx]);
         if (!rms_only) {
           warp_buf1[write_idx] = curr_dout;
-          warp_buf2[write_idx] = curr_dout * (curr_input - curr_mean) * curr_invvar;
+          if (MemoryEfficient) {
+            U curr_beta = static_cast<U>(beta[i2]);
+            warp_buf2[write_idx] = curr_dout * (c_h - curr_beta) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] = curr_dout * (c_h - mean[i1]) * invvar[i1];
+          }
         } else {
-          warp_buf2[write_idx] = curr_dout * (curr_input) * curr_invvar;
+          if (MemoryEfficient) {
+            warp_buf2[write_idx] = curr_dout * (c_h) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] = curr_dout * (c_h) * invvar[i1];
+          }
         }
       } else {
         if (!rms_only) {
@@ -501,7 +565,8 @@ void cuLoadWriteStridedInputs(
     }
   }
 }
-template<typename T, typename U, typename V> __device__
+
+template<typename T, typename U, typename V, bool MemoryEfficient> __device__
 void cuLoadAddStridedInputs(
     const int i1_block,
     const int thr_load_row_off,
@@ -510,34 +575,41 @@ void cuLoadAddStridedInputs(
     const int row_stride,
     U* warp_buf1,
     U* warp_buf2,
-    const T* input,
+    const T* input_or_output,
     const V* dout,
     const int i1_end,
     const int n2,
     const U* __restrict__ mean,
     const U* __restrict__ invvar,
+    const V* __restrict__ gamma,
+    const V* __restrict__ beta,
+    const double eps,
     bool rms_only
     )
 {
   int i1 = i1_block+thr_load_row_off;
   if (i1 < i1_end) {
-    U curr_mean;
-    if (!rms_only) {
-      curr_mean = mean[i1];
-    }
-    U curr_invvar = invvar[i1];
     for (int k = 0;  k < blockDim.y;  ++k) {
       int i2 = i2_off + k;
       int load_idx = i1*n2+i2;
       int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
       if (i2<n2) {
-        U curr_input = static_cast<U>(input[load_idx]);
+        U c_h = static_cast<U>(input_or_output[load_idx]);
         U curr_dout = static_cast<U>(dout[load_idx]);
         if (!rms_only) {
+          U curr_beta = static_cast<U>(beta[i2]);
           warp_buf1[write_idx] += curr_dout;
-          warp_buf2[write_idx] += curr_dout * (curr_input - curr_mean) * curr_invvar;
+          if (MemoryEfficient) {
+            warp_buf2[write_idx] += curr_dout * (c_h - curr_beta) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] += curr_dout * (c_h - mean[i1]) * invvar[i1];
+          }
         } else {
-          warp_buf2[write_idx] += curr_dout * (curr_input) * curr_invvar;
+          if (MemoryEfficient) {
+            warp_buf2[write_idx] += curr_dout * (c_h) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] += curr_dout * (c_h) * invvar[i1];
+          }
         }
       }
     }
@@ -545,17 +617,20 @@ void cuLoadAddStridedInputs(
 }
 
 
-template<typename T, typename U, typename V> __global__
+template<typename T, typename U, typename V, bool MemoryEfficient> __global__
 void cuComputePartGradGammaBeta(
     const V* __restrict__ dout,
-    const T* __restrict__ input,
+    const T* __restrict__ input_or_output,
     const int n1,
     const int n2,
     const U* __restrict__ mean,
     const U* __restrict__ invvar,
     U epsilon,
+    const V* __restrict__ gamma,
+    const V* __restrict__ beta,
     U* part_grad_gamma,
     U* part_grad_beta,
+    const double eps,
     bool rms_only)
 {
     const int numsegs_n1 = (n1+blockDim.y*blockDim.y-1) / (blockDim.y*blockDim.y);
@@ -573,9 +648,9 @@ void cuComputePartGradGammaBeta(
     U* warp_buf2 = warp_buf1 + blockDim.y * blockDim.y * row_stride;
     // compute partial sums from strided inputs
     // do this to increase number of loads in flight
-    cuLoadWriteStridedInputs(i1_beg,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input,dout,i1_end,n2,mean,invvar, rms_only);
+    cuLoadWriteStridedInputs<T, U, V, MemoryEfficient>(i1_beg,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input_or_output,dout,i1_end,n2,mean,invvar,gamma,beta,eps, rms_only);
     for (int i1_block = i1_beg+blockDim.y*blockDim.y;  i1_block < i1_end;  i1_block+=blockDim.y*blockDim.y) {
-      cuLoadAddStridedInputs(i1_block,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input,dout,i1_end,n2,mean,invvar, rms_only);
+      cuLoadAddStridedInputs<T, U, V, MemoryEfficient>(i1_block,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input_or_output,dout,i1_end,n2,mean,invvar,gamma,beta,eps, rms_only);
     }
     __syncthreads();
     // inter-warp reductions
@@ -683,110 +758,110 @@ void cuComputeGradGammaBeta(
 }
 
 
-template<typename T, typename U, typename V> __global__
+template<typename T, typename U, typename V, bool MemoryEfficient> __global__
 void cuComputeGradInput(
     const V* __restrict__ dout,
-    const T* __restrict__ input,
+    const T* __restrict__ input_or_output,
     const int n1,
     const int n2,
     const U* __restrict__ mean,
     const U* __restrict__ invvar,
     U epsilon,
     const V* gamma,
+    const V* beta,
     T* grad_input,
+    const double eps,
     bool rms_only)
 {
-  for (int i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
+  for (auto i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
     U sum_loss1 = U(0);
     U sum_loss2 = U(0);
-    U c_mean;
-    if (!rms_only) {
-      c_mean = mean[i1];
-    }
-    const U c_invvar = invvar[i1];
-    const T* k_input = input + i1*n2;
+    const T* k_h = input_or_output + i1*n2;
     const V* k_dout = dout + i1*n2;
+    const U c_invvar = invvar[i1];
+    const U c_mean = !MemoryEfficient ? mean[i1] : 0.;
     const int numx = blockDim.x * blockDim.y;
     const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
     if (gamma != NULL) {
-      #ifndef USE_ROCM
       int l = 4*thrx;
-      for (;  l+3 < n2;  l+=4*numx) {           
+      for (;  l+3 < n2;  l+=4*numx) {
         for (int k = 0;  k < 4;  ++k) {
-          const U c_h = static_cast<U>(k_input[l+k]);
+          const U c_h = static_cast<U>(k_h[l+k]);
           const U c_loss = static_cast<U>(k_dout[l+k]);
           if (!rms_only) {
             sum_loss1 += c_loss * gamma[l+k];
-            sum_loss2 += c_loss * gamma[l+k] * (c_h - c_mean) * c_invvar;
+            if (MemoryEfficient) {
+              sum_loss2 += c_loss * (c_h - beta[l+k]);
+            } else {
+              sum_loss2 += c_loss * gamma[l+k] * (c_h - c_mean) * c_invvar;
+            }
           } else {
-            sum_loss2 += c_loss * gamma[l+k] * (c_h) * c_invvar;
+            if (MemoryEfficient) {
+              sum_loss2 += c_loss * c_h;
+            } else {
+              sum_loss2 += c_loss * gamma[l+k] * (c_h) * c_invvar;
+            }
           }
         }
       }
       for (;  l < n2;  ++l) {
-        const U c_h = static_cast<U>(k_input[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         if (!rms_only) {
           sum_loss1 += c_loss * gamma[l];
-          sum_loss2 += c_loss * gamma[l] * (c_h - c_mean) * c_invvar;
+          if (MemoryEfficient) {
+            sum_loss2 += c_loss * (c_h - beta[l]);
+          } else {
+            sum_loss2 += c_loss * gamma[l] * (c_h - c_mean) * c_invvar;
+          }
         } else {
-          sum_loss2 += c_loss * gamma[l] * (c_h) * c_invvar;
-        }
-
-      }
-      #else
-      // Optimization for ROCm MI100
-      for( int l = 0; l < n2 ; l += numx) {
-        int idx = l + thrx;
-        const U gamma_idx = static_cast<U>((idx<n2) ? gamma[idx] : V(0));
-        const U c_h = static_cast<U>((idx<n2) ? k_input[idx] : T(0));
-        const U c_loss = static_cast<U>((idx<n2) ? k_dout[idx] : V(0));
-        if (!rms_only) {
-          sum_loss1 += c_loss * gamma_idx;
-          sum_loss2 += c_loss * gamma_idx * (c_h - c_mean) * c_invvar;
-        } else {
-          sum_loss2 += c_loss * gamma_idx * (c_h) * c_invvar;
+          if (MemoryEfficient) {
+            sum_loss2 += c_loss * c_h;
+          } else {
+            sum_loss2 += c_loss * gamma[l] * (c_h) * c_invvar;
+          }
         }
       }
-      #endif
     } else {
-      #ifndef USE_ROCM
       int l = 4*thrx;
       for (;  l+3 < n2;  l+=4*numx) {
         for (int k = 0;  k < 4;  ++k) {
-          const U c_h = static_cast<U>(k_input[l+k]);
+          const U c_h = static_cast<U>(k_h[l+k]);
           const U c_loss = static_cast<U>(k_dout[l+k]);
           if (!rms_only) {
             sum_loss1 += c_loss;
+            if (MemoryEfficient) {
+              sum_loss2 += c_loss * c_h;
+            } else {
+              sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+            }
+          } else {
+            if (MemoryEfficient) {
+              sum_loss2 += c_loss * c_h;
+            } else {
+              sum_loss2 += c_loss * (c_h) * c_invvar;
+            }
+          }
+        }
+      }
+      for (;  l < n2;  ++l) {
+        const U c_h = static_cast<U>(k_h[l]);
+        const U c_loss = static_cast<U>(k_dout[l]);
+        if (!rms_only) {
+          sum_loss1 += c_loss;
+          if (MemoryEfficient) {
+            sum_loss2 += c_loss * c_h;
+          } else {
             sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+          }
+        } else {
+          if (MemoryEfficient) {
+            sum_loss2 += c_loss * c_h;
           } else {
             sum_loss2 += c_loss * (c_h) * c_invvar;
           }
         }
       }
-      for (;  l < n2;  ++l) {
-        const U c_h = static_cast<U>(k_input[l]);
-        const U c_loss = static_cast<U>(k_dout[l]);
-        if (!rms_only) {
-          sum_loss1 += c_loss;
-          sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
-        } else {
-          sum_loss2 += c_loss * (c_h) * c_invvar;
-        }
-      }
-      #else
-      for( int l = 0; l < n2 ; l += numx) {
-        int idx = l + thrx;
-        const U c_h = static_cast<U>((idx<n2) ? k_input[idx] : T(0));
-        const U c_loss = static_cast<U>((idx<n2) ? k_dout[idx] : V(0));
-        if (!rms_only) {
-          sum_loss1 += c_loss;
-          sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
-        } else {
-          sum_loss2 += c_loss * (c_h) * c_invvar;
-        }
-      }
-      #endif
     }
     // intra-warp reductions
     for (int mask = blockDim.x/2;  mask > 0;  mask /= 2) {
@@ -839,28 +914,46 @@ void cuComputeGradInput(
     T* k_grad_input = grad_input + i1*n2;
     if (gamma != NULL) {
       for (int l = thrx;  l < n2;  l+=numx) {
-        const U c_h = static_cast<U>(k_input[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
-        U f_grad_input = fH * c_loss * gamma[l];
+        const U k_gamma = static_cast<U>(clamp_by_magnitude(gamma[l], eps));
+        U f_grad_input = fH * c_loss * k_gamma;
         if (!rms_only) {
+          const U k_beta = beta[l];
           f_grad_input -= sum_loss1;
-          f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+          if (MemoryEfficient) {
+            f_grad_input -= (c_h - k_beta) / k_gamma * sum_loss2;
+          } else {
+            f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+          }
         } else {
-          f_grad_input -= (c_h) * c_invvar * sum_loss2;
+          if (MemoryEfficient) {
+            f_grad_input -= c_h / k_gamma * sum_loss2;
+          } else {
+            f_grad_input -= c_h * c_invvar * sum_loss2;
+          }
         }
         f_grad_input *= term1;
         k_grad_input[l] = static_cast<T>(f_grad_input);
       }
     } else {
       for (int l = thrx;  l < n2;  l+=numx) {
-        const U c_h = static_cast<U>(k_input[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         U f_grad_input = fH * c_loss;
         if (!rms_only) {
           f_grad_input -= sum_loss1;
-          f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+          if (MemoryEfficient) {
+            f_grad_input -= c_h * sum_loss2;
+          } else {
+            f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+          }
         } else {
-          f_grad_input -= (c_h) * c_invvar * sum_loss2;
+          if (MemoryEfficient) {
+            f_grad_input -= c_h * sum_loss2;
+          } else {
+            f_grad_input -= c_h * c_invvar * sum_loss2;
+          }
         }
         f_grad_input *= term1;
         k_grad_input[l] = static_cast<T>(f_grad_input);
@@ -899,11 +992,11 @@ void HostApplyLayerNorm(
         threads.y > 1 ?
             threads.y*sizeof(U)+(threads.y/2)*sizeof(U) :
             0;
+    
     cuApplyLayerNorm<<<blocks, threads, nshared, stream>>>(
       output, mean, invvar, input, n1, n2, U(epsilon), gamma, beta, warp_size);
 }
 
-// Optimize HostRMSNormGradient for AMD GPUs: https://github.com/ROCmSoftwarePlatform/apex/pull/66/files
 template<typename T, typename U, typename V=T>
 void HostApplyRMSNorm(
     V* output,
@@ -997,7 +1090,7 @@ void HostLayerNormGradient(
     const V* dout,
     const U* mean,
     const U* invvar,
-    at::Tensor* input,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     const V* gamma,
@@ -1005,41 +1098,46 @@ void HostLayerNormGradient(
     double epsilon,
     T* grad_input,
     V* grad_gamma,
-    V* grad_beta
+    V* grad_beta,
+    bool memory_efficient
     )
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
-    const int warp_size = at::cuda::warp_size();
-    
+
     if (gamma != NULL && beta != NULL) {
       // compute grad_gamma(j) and grad_beta(j)
-      // Optimize layer normalization for AMD GPUs: https://github.com/ROCmSoftwarePlatform/apex/pull/66/files
-      const int part_size = warp_size;
-      const dim3 threads2(warp_size, 4, 1);
-      const dim3 blocks2((n2+threads2.x-1) / threads2.x,part_size, 1);
+      const int part_size = 16;
+      const dim3 threads2(32,4,1);
+      const dim3 blocks2((n2+threads2.x-1)/threads2.x,part_size,1);
       const int nshared2_a = 2 * sizeof(U) * threads2.y * threads2.y * (threads2.x + 1);
       const int nshared2_b = threads2.x * threads2.y * sizeof(U);
       const int nshared2 = nshared2_a > nshared2_b ? nshared2_a : nshared2_b;
       // note (mkozuki): I can hard code part_grad_gamma's dtype as float given that
       // the `cuda_layer_norm_gradient` doesn't support double.
       const auto part_grad_dtype =
-        (input->scalar_type() == at::ScalarType::Half || input->scalar_type() == at::ScalarType::BFloat16) ?
+        (input_or_output->scalar_type() == at::ScalarType::Half || input_or_output->scalar_type() == at::ScalarType::BFloat16) ?
         at::ScalarType::Float :
-        input->scalar_type();
-      at::Tensor part_grad_gamma = at::empty({part_size,n2}, input->options().dtype(part_grad_dtype));
+        input_or_output->scalar_type();
+      at::Tensor part_grad_gamma = at::empty({part_size,n2}, input_or_output->options().dtype(part_grad_dtype));
       at::Tensor part_grad_beta = at::empty_like(part_grad_gamma);
-      cuComputePartGradGammaBeta<<<blocks2, threads2, nshared2, stream>>>(
-                      dout,
-                      input->DATA_PTR<T>(),
-                      n1,n2,
-                      mean,
-                      invvar,
-                      U(epsilon),
-                      part_grad_gamma.DATA_PTR<U>(),
-                      part_grad_beta.DATA_PTR<U>(),
-                      false);
+      BOOL_SWITCH(memory_efficient, MemoryEfficient, [&]{
+        auto kernel = &cuComputePartGradGammaBeta<T, U, V, MemoryEfficient>;
+        kernel<<<blocks2, threads2, nshared2, stream>>>(
+                        dout,
+                        input_or_output->DATA_PTR<T>(),
+                        n1,n2,
+                        mean,
+                        invvar,
+                        U(epsilon),
+                        gamma,
+                        beta,
+                        part_grad_gamma.DATA_PTR<U>(),
+                        part_grad_beta.DATA_PTR<U>(),
+                        epsilon,
+                        false);
+      });
 
-      const dim3 threads3(warp_size, 8, 1);
+      const dim3 threads3(32,8,1);
       const dim3 blocks3((n2+threads2.x-1)/threads2.x,1,1);
       const int nshared3 = threads3.x * threads3.y * sizeof(U);
       cuComputeGradGammaBeta<<<blocks3, threads3, nshared3, stream>>>(
@@ -1053,49 +1151,48 @@ void HostLayerNormGradient(
     }
 
     // compute grad_input
-    // https://github.com/microsoft/onnxruntime/pull/7682/files#diff-f9eace25e62b646410b067f96cd930c7fe843326dca1e8d383631ca27f1a8d00R540
-    // https://github.com/amathews-amd/onnxruntime/blob/80c0555c2bc17fb109190e2082cd3fda0a37984c/orttraining/orttraining/training_ops/cuda/nn/layer_norm_impl.cu#L541
-    
     const uint64_t maxGridY = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
     const dim3 blocks1(1, std::min((uint64_t)n1, maxGridY), 1);
-    dim3 threads1(warp_size,4,1);  // MI100 wavefront/warp = 64
-    #ifdef USE_ROCM
-    // Optimization for ROCm MI100
-    threads1.y = 2;
-    #endif
+    const dim3 threads1(32,4,1);
     int nshared =
             threads1.y > 1 ?
             threads1.y*threads1.x*sizeof(U) :
             0;
-    cuComputeGradInput<<<blocks1, threads1, nshared, stream>>>(
-            dout,
-            input->DATA_PTR<T>(),
-            n1,n2,
-            mean,
-            invvar,
-            U(epsilon),
-            gamma,
-            grad_input,
-            false);
+    BOOL_SWITCH(memory_efficient, MemoryEfficient, [&] {
+      auto kernel = cuComputeGradInput<T, U, V, MemoryEfficient>;
+      kernel<<<blocks1, threads1, nshared, stream>>>(
+              dout,
+              input_or_output->DATA_PTR<T>(),
+              n1,n2,
+              mean,
+              invvar,
+              U(epsilon),
+              gamma,
+              beta,
+              grad_input,
+              epsilon,
+              false);
+    });
 }
-// Optimize HostRMSNormGradient for AMD GPUs: https://github.com/ROCmSoftwarePlatform/apex/pull/66/files
+
 template<typename T, typename U=float, typename V=T>
 void HostRMSNormGradient(
     const V* dout,
     const U* invvar,
-    at::Tensor* input,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     const V* gamma,
     double epsilon,
     T* grad_input,
-    V* grad_gamma)
+    V* grad_gamma,
+    bool memory_efficient)
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
-    const int warp_size = at::cuda::warp_size();
+
     if (gamma != NULL) {
-      const int part_size = warp_size;
-      const dim3 threads2(warp_size,4,1);
+      const int part_size = 16;
+      const dim3 threads2(32,4,1);
       const dim3 blocks2((n2+threads2.x-1)/threads2.x,part_size,1);
       const int nshared2_a = 2 * sizeof(U) * threads2.y * threads2.y * (threads2.x + 1);
       const int nshared2_b = threads2.x * threads2.y * sizeof(U);
@@ -1103,22 +1200,29 @@ void HostRMSNormGradient(
       // note (mkozuki): I can hard code part_grad_gamma's dtype as float given that
       // the `cuda_layer_norm_gradient` doesn't support double.
       const auto part_grad_dtype =
-        (input->scalar_type() == at::ScalarType::Half || input->scalar_type() == at::ScalarType::BFloat16) ?
+        (input_or_output->scalar_type() == at::ScalarType::Half || input_or_output->scalar_type() == at::ScalarType::BFloat16) ?
         at::ScalarType::Float :
-        input->scalar_type();
-      at::Tensor part_grad_gamma = at::empty({part_size,n2}, input->options().dtype(part_grad_dtype));
-      cuComputePartGradGammaBeta<<<blocks2, threads2, nshared2, stream>>>(
-                      dout,
-                      input->DATA_PTR<T>(),
-                      n1,n2,
-                      invvar, // unused
-                      invvar,
-                      U(epsilon),
-                      part_grad_gamma.DATA_PTR<U>(),
-                      part_grad_gamma.DATA_PTR<U>(), /* unused */
-                      true);
+        input_or_output->scalar_type();
+      at::Tensor part_grad_gamma = at::empty({part_size,n2}, input_or_output->options().dtype(part_grad_dtype));
+      BOOL_SWITCH(memory_efficient, MemoryEfficient, [&]{
+        auto kernel = &cuComputePartGradGammaBeta<T, U, V, MemoryEfficient>;
+        kernel<<<blocks2, threads2, nshared2, stream>>>(
+                        dout,
+                        input_or_output->DATA_PTR<T>(),
+                        n1,n2,
+                        invvar, /* unused */
+                        invvar,
+                        U(epsilon),
+                        gamma,
+                        gamma, /* unused */
+                        part_grad_gamma.DATA_PTR<U>(),
+                        part_grad_gamma.DATA_PTR<U>(), /* unused */
+                        epsilon,
+                        true);
+      });
+            
 
-      const dim3 threads3(warp_size,8,1);
+      const dim3 threads3(32,8,1);
       const dim3 blocks3((n2+threads2.x-1)/threads2.x,1,1);
       const int nshared3 = threads3.x * threads3.y * sizeof(U);
       cuComputeGradGammaBeta<<<blocks3, threads3, nshared3, stream>>>(
@@ -1134,28 +1238,33 @@ void HostRMSNormGradient(
     // compute grad_input
     const uint64_t maxGridY = at::cuda::getCurrentDeviceProperties()->maxGridSize[1];
     const dim3 blocks1(1, std::min((uint64_t)n1, maxGridY), 1);
-    const dim3 threads1(warp_size,4,1);
+    const dim3 threads1(32,4,1);
     int nshared =
             threads1.y > 1 ?
             threads1.y*threads1.x*sizeof(U) :
             0;
-    cuComputeGradInput<<<blocks1, threads1, nshared, stream>>>(
-            dout,
-            input->DATA_PTR<T>(),
-            n1,n2,
-            invvar, /* unused */
-            invvar,
-            U(epsilon),
-            gamma,
-            grad_input,
-            true);
+    BOOL_SWITCH(memory_efficient, MemoryEfficient, [&] {
+      auto kernel = cuComputeGradInput<T, U, V, MemoryEfficient>;
+      kernel<<<blocks1, threads1, nshared, stream>>>(
+              dout,
+              input_or_output->DATA_PTR<T>(),
+              n1,n2,
+              invvar, /* unused */
+              invvar,
+              U(epsilon),
+              gamma,
+              gamma, /* unused */
+              grad_input,
+              epsilon,
+              true);
+    });
 }
 
 void cuda_layer_norm_gradient(
     at::Tensor* dout,
     at::Tensor* mean,
     at::Tensor* invvar,
-    at::Tensor* input,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -1168,18 +1277,19 @@ void cuda_layer_norm_gradient(
     double epsilon,
     at::Tensor* grad_input,
     at::Tensor* grad_gamma,
-    at::Tensor* grad_beta)
+    at::Tensor* grad_beta,
+    bool memory_efficient)
 {
     using namespace at;
     // we can do away with `accscalar_t` as there're only three dtypes: fp32, fp16, bf16
     DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
-      input->scalar_type(), gamma == NULL ? input->scalar_type() :  gamma->scalar_type(), "cuComputeGradInput",
+      input_or_output->scalar_type(), gamma == NULL ? input_or_output->scalar_type() :  gamma->scalar_type(), "cuComputeGradInput",
       using accscalar_t = at::acc_type<scalar_t_in, true>;
       HostLayerNormGradient(
         dout->DATA_PTR<scalar_t_out>(),
-        mean->DATA_PTR<accscalar_t>(),
+        mean != NULL ? mean->DATA_PTR<accscalar_t>() : NULL,
         invvar->DATA_PTR<accscalar_t>(),
-        input,
+        input_or_output,
         n1,n2,
             // TMJ pass NULL argument for gamma, beta, grad_gamma and grad_beta
             // if gamma Tensor is NULL on input.
@@ -1188,14 +1298,15 @@ void cuda_layer_norm_gradient(
         epsilon,
         grad_input->DATA_PTR<scalar_t_in>(),
         gamma != NULL ? grad_gamma->DATA_PTR<scalar_t_out>() : NULL,
-        gamma != NULL ? grad_beta->DATA_PTR<scalar_t_out>() : NULL);
+        gamma != NULL ? grad_beta->DATA_PTR<scalar_t_out>() : NULL,
+        memory_efficient);
     )
 }
 
 void cuda_rms_norm_gradient(
     at::Tensor* dout,
     at::Tensor* invvar,
-    at::Tensor* input,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -1206,24 +1317,26 @@ void cuda_rms_norm_gradient(
     at::Tensor* gamma,
     double epsilon,
     at::Tensor* grad_input,
-    at::Tensor* grad_gamma)
+    at::Tensor* grad_gamma,
+    bool memory_efficient)
 {
     using namespace at;
     // we can do away with `accscalar_t` as there're only three dtypes: fp32, fp16, bf16
     // DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
     DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
-      input->scalar_type(), gamma == NULL ? input->scalar_type() :  gamma->scalar_type(), "cuComputeGradInputRMS",
+      input_or_output->scalar_type(), gamma == NULL ? input_or_output->scalar_type() :  gamma->scalar_type(), "cuComputeGradInputRMS",
       using accscalar_t = at::acc_type<scalar_t_in, true>;
       HostRMSNormGradient(
         dout->DATA_PTR<scalar_t_out>(),
         invvar->DATA_PTR<accscalar_t>(),
-        input,
+        input_or_output,
         n1,n2,
             // TMJ pass NULL argument for gamma, beta, grad_gamma and grad_beta
             // if gamma Tensor is NULL on input.
         gamma != NULL ? gamma->DATA_PTR<scalar_t_out>() : NULL,
         epsilon,
         grad_input->DATA_PTR<scalar_t_in>(),
-        gamma != NULL ? grad_gamma->DATA_PTR<scalar_t_out>() : NULL);
+        gamma != NULL ? grad_gamma->DATA_PTR<scalar_t_out>() : NULL,
+        memory_efficient);
     )
 }

--- a/csrc/static_switch.h
+++ b/csrc/static_switch.h
@@ -1,0 +1,25 @@
+// From
+// https://github.com/NVIDIA/DALI/blob/main/include/dali/core/static_switch.h
+
+#pragma once
+
+/// @param COND       - a boolean expression to switch by
+/// @param CONST_NAME - a name given for the constexpr bool variable.
+/// @param ...       - code to execute for true and false
+///
+/// Usage:
+/// ```
+/// BOOL_SWITCH(flag, BoolConst, [&] {
+///     some_function<BoolConst>(...);
+/// });
+/// ```
+#define BOOL_SWITCH(COND, CONST_NAME, ...)      \
+  [&] {                                         \
+    if (COND) {                                 \
+      constexpr static bool CONST_NAME = true;  \
+      return __VA_ARGS__();                     \
+    } else {                                    \
+      constexpr static bool CONST_NAME = false; \
+      return __VA_ARGS__();                     \
+    }                                           \
+  }()

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -1,226 +1,13 @@
-import itertools
-import unittest
-
 import torch
+from apex.normalization import FusedLayerNorm
+from apex.normalization import FusedRMSNorm
+from apex.normalization import MixedFusedLayerNorm
+from apex.normalization import MixedFusedRMSNorm
 
-import apex
-from apex.testing.common_utils import skipFlakyTest
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
-class TestFusedLayerNorm(unittest.TestCase):
-    dtype = torch.float
-    elementwise_affine = False
-    normalized_shape = [32, 16]
-    rtol, atol = None, None
-    fwd_thresholds = dict(rtol=None, atol=None)
-    bwd_thresholds = dict(rtol=None, atol=None)
-    mixed_fused = False
-
-    def setUp(self):
-        # bias and weight are set to 0 and 1 respectively, so no need to copy parameters from cpu module to the gpu one
-        if not self.mixed_fused:
-            self.module_cpu_ = apex.normalization.FusedLayerNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).cpu()
-            self.module_cuda_ = apex.normalization.FusedLayerNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).to(device="cuda", dtype=self.dtype)
-        else:
-            assert self.elementwise_affine
-            self.module_cpu_ = apex.normalization.MixedFusedLayerNorm(
-                normalized_shape=self.normalized_shape).cpu()
-            self.module_cuda_ = apex.normalization.MixedFusedLayerNorm(
-                normalized_shape=self.normalized_shape).to(device="cuda", dtype=self.dtype)
-
-
-    def _check_same_output(self, batch_size, contiguous):
-        torch.cuda.manual_seed(42)
-        if contiguous:
-            input_shape = [batch_size] + self.normalized_shape
-            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
-            input_cuda_ = input_.to(device="cuda", dtype=self.dtype).detach().requires_grad_(True)
-            self.assertTrue(input_.is_contiguous())
-            self.assertTrue(input_cuda_.is_contiguous())
-        else:
-            input_shape = [batch_size] + self.normalized_shape
-            input_shape = [batch_size * 3] + [self.normalized_shape[0] * 5, self.normalized_shape[1] * 3]
-            input_src_ = torch.randn(input_shape, device="cpu")
-            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
-            input_cuda_ = input_src_.to(device="cuda", dtype=self.dtype)[::3, ::5, ::3].detach().requires_grad_(True)
-            # make sure that tensors are NOT contiguous.
-            self.assertFalse(input_.is_contiguous())
-            self.assertFalse(input_cuda_.is_contiguous())
-        out_cpu_ = self.module_cpu_(input_)
-        gO = torch.rand_like(out_cpu_)
-        out_cpu_.backward(gO)
-        out_cuda_ = self.module_cuda_(input_cuda_)
-        gO = gO.to(device="cuda", dtype=self.dtype)
-        out_cuda_.backward(gO)
-        self.assertFalse(out_cpu_.is_cuda)
-        self.assertTrue(out_cuda_.is_cuda)
-        # TODO (mkozuki): `torch.testing.assert_allclose` is deprecated.
-        # Use `torch.testing.assert_close`.
-        # See https://github.com/pytorch/pytorch/issues/61844
-        torch.testing.assert_allclose(
-            out_cpu_.to(device="cuda", dtype=self.dtype), out_cuda_, **self.fwd_thresholds)
-        torch.testing.assert_allclose(
-            input_.grad.to(device="cuda", dtype=self.dtype), input_cuda_.grad, **self.bwd_thresholds)
-
-    def _test_same_output(self, batch_size):
-        for contiguous in (True, False):
-            with self.subTest(contiguous=contiguous):
-                self._check_same_output(batch_size, contiguous)
-
-    def test_layer_norm(self):
-        self._test_same_output(16)
-
-    def test_large_batch(self):
-        self._test_same_output(65536)
-
-
-class TestFusedRMSNorm(unittest.TestCase):
-    dtype = torch.float
-    elementwise_affine = False
-    normalized_shape = [32, 16]
-    rtol, atol = None, None
-    fwd_thresholds = dict(rtol=None, atol=None)
-    bwd_thresholds = dict(rtol=None, atol=None)
-    mixed_fused = False
-
-    def setUp(self):
-        # bias and weight are set to 0 and 1 respectively, so no need to copy parameters from cpu module to the gpu one
-        if not self.mixed_fused:
-            self.module_cpu_ = apex.normalization.FusedRMSNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).cpu()
-            self.module_cuda_ = apex.normalization.FusedRMSNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).to(device="cuda", dtype=self.dtype)
-        else:
-            assert self.elementwise_affine
-            self.module_cpu_ = apex.normalization.MixedFusedRMSNorm(
-                normalized_shape=self.normalized_shape).cpu()
-            self.module_cuda_ = apex.normalization.MixedFusedRMSNorm(
-                normalized_shape=self.normalized_shape).to(device="cuda", dtype=self.dtype)
-
-    def _check_same_output(self, batch_size, contiguous):
-        torch.cuda.manual_seed(42)
-        if contiguous:
-            input_shape = [batch_size] + self.normalized_shape
-            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
-            input_cuda_ = input_.to(device="cuda", dtype=self.dtype).detach().requires_grad_(True)
-            self.assertTrue(input_.is_contiguous())
-            self.assertTrue(input_cuda_.is_contiguous())
-        else:
-            input_shape = [batch_size] + self.normalized_shape
-            input_shape = [batch_size * 3] + [self.normalized_shape[0] * 5, self.normalized_shape[1] * 3]
-            input_src_ = torch.randn(input_shape, device="cpu")
-            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
-            input_cuda_ = input_src_.to(device="cuda", dtype=self.dtype)[::3, ::5, ::3].detach().requires_grad_(True)
-            # make sure that tensors are NOT contiguous.
-            self.assertFalse(input_.is_contiguous())
-            self.assertFalse(input_cuda_.is_contiguous())
-        out_cpu_ = self.module_cpu_(input_)
-        gO = torch.rand_like(out_cpu_)
-        out_cpu_.backward(gO)
-        out_cuda_ = self.module_cuda_(input_cuda_)
-        # TODO (mkozuki): `torch.testing.assert_allclose` is deprecated.
-        # Use `torch.testing.assert_close`.
-        # See https://github.com/pytorch/pytorch/issues/61844
-        torch.testing.assert_allclose(
-            out_cpu_.to(device="cuda", dtype=self.dtype), out_cuda_.clone().detach(), **self.fwd_thresholds)
-        gO = gO.to(device="cuda", dtype=self.dtype)
-        out_cuda_.backward(gO)
-        self.assertFalse(out_cpu_.is_cuda)
-        self.assertTrue(out_cuda_.is_cuda)
-        torch.testing.assert_allclose(
-            input_.grad.to(device="cuda", dtype=self.dtype), input_cuda_.grad, **self.bwd_thresholds)
-        if self.elementwise_affine:
-            torch.testing.assert_allclose(self.module_cpu_.weight.grad.to(device="cuda", dtype=self.dtype),
-                                          self.module_cuda_.weight.grad, **self.bwd_thresholds)
-
-    def _test_same_output(self, batch_size):
-        for contiguous in (True, False):
-            with self.subTest(contiguous=contiguous):
-                self._check_same_output(batch_size, contiguous)
-
-    def test_layer_norm(self):
-        self._test_same_output(16)
-
-    def test_large_batch(self):
-        self._test_same_output(65536)
-
-
-class TestFusedLayerNormElemWise(TestFusedLayerNorm):
-    elementwise_affine = True
-
-class TestMixedFusedLayerNormElemWise(TestFusedLayerNorm):
-    elementwise_affine = True
-    mixed_fused = True
-
-class TestFusedLayerNormElemWiseHalf(TestFusedLayerNormElemWise):
-    dtype = torch.half
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-class TestFusedLayerNormElemWiseBFloat16(TestFusedLayerNormElemWise):
-    dtype = torch.bfloat16
-    # NOTE (mkozuki): [BFloat16 Layer Norm flakiness]
-    # Use thresholds larger than those used in pytorch, see
-    # https://github.com/pytorch/pytorch/blob/72274e2a2fd55019ec860e1743dbdc5b0c5a5624/torch/testing/_asserts.py#L26
-    fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-
-class TestFusedRMSNormElemWise(TestFusedRMSNorm):
-    bwd_thresholds = dict(rtol=2e-3, atol=2e-4)
-    elementwise_affine = True
-
-class TestMixedFusedRMSNormElemWise(TestFusedRMSNorm):
-    bwd_thresholds = dict(rtol=2e-3, atol=2e-4)
-    elementwise_affine = True
-    mixed_fused = True
-
-@skipFlakyTest
-class TestFusedRMSNormElemWiseHalf(TestFusedRMSNormElemWise):
-    dtype = torch.half
-    bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-
-@skipFlakyTest
-class TestFusedLayerNormElemWiseBFloat16(TestFusedLayerNormElemWise):
-    dtype = torch.bfloat16
-    # NOTE (mkozuki): [BFloat16 Layer Norm flakiness]
-    # Use thresholds larger than those used in pytorch, see
-    # https://github.com/pytorch/pytorch/blob/72274e2a2fd55019ec860e1743dbdc5b0c5a5624/torch/testing/_asserts.py#L26
-    fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-
-def _prep_layers(normalized_shape, elementwise_affine, dtype):
-    native = torch.nn.LayerNorm(
-        normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
-    ).to(device="cuda", dtype=dtype)
-    fused = apex.normalization.FusedLayerNorm(
-        normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
-    ).cuda()
-    return native, fused
-
-
-def _prep_rms_layers(normalized_shape, elementwise_affine, dtype):
-    native = apex.normalization.FusedRMSNorm(
-        normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
-    )
-    fused = apex.normalization.FusedRMSNorm(
-        normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
-    ).cuda()
-    return native, fused
-
+from itertools import product
 
 def _prep_inputs(batch_size, normalized_shape, dtype):
     shape = (batch_size, *normalized_shape)
@@ -229,26 +16,219 @@ def _prep_inputs(batch_size, normalized_shape, dtype):
         native = fused.clone().to(dtype).requires_grad_(True)
     return native, fused
 
-
 autocast_dtypes = (torch.half, torch.bfloat16) if torch.cuda.is_bf16_supported() else (torch.half,)
 
-class TestAutocastFusedLayerNorm(unittest.TestCase):
-    bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
+class TestFusedLayerNorm(common_utils.TestCase):
 
-    def setUp(self):
-        self.batch_size = 16
-        self.normalized_shape = [32, 16]
+    def _test_fused_layer_norm(
+        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
+        fwd_thresholds=dict(rtol=None, atol=None), bwd_thresholds=dict(rtol=None, atol=None)
+        ):
 
-    def _run_test(self, dtype, elementwise_affine):
-        native, fused = _prep_layers(self.normalized_shape, elementwise_affine, dtype)
-        native_x, fused_x = _prep_inputs(self.batch_size, self.normalized_shape, dtype)
+        normalized_shape = [32, 16]
+
+        if not mixed_fused:
+            module_cpu_ = FusedLayerNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).cpu()
+            module_cuda_ = FusedLayerNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).to(device="cuda", dtype=dtype)
+        else:
+            assert elementwise_affine
+            module_cpu_ = MixedFusedLayerNorm(
+                normalized_shape=normalized_shape, memory_efficient=memory_efficient
+            ).cpu()
+            module_cuda_ = MixedFusedLayerNorm(
+                normalized_shape=normalized_shape, memory_efficient=memory_efficient
+            ).to(device="cuda", dtype=dtype)
+
+        torch.cuda.manual_seed(42)
+        if contiguous:
+            input_shape = [batch_size] + normalized_shape
+            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
+            input_cuda_ = input_.to(device="cuda", dtype=dtype).detach().requires_grad_(True)
+            self.assertTrue(input_.is_contiguous())
+            self.assertTrue(input_cuda_.is_contiguous())
+        else:
+            input_shape = [batch_size] + normalized_shape
+            input_shape = [batch_size * 3] + [normalized_shape[0] * 5, normalized_shape[1] * 3]
+            input_src_ = torch.randn(input_shape, device="cpu")
+            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
+            input_cuda_ = input_src_.to(device="cuda", dtype=dtype)[::3, ::5, ::3].detach().requires_grad_(True)
+            # make sure that tensors are NOT contiguous.
+            self.assertFalse(input_.is_contiguous())
+            self.assertFalse(input_cuda_.is_contiguous())
+        out_cpu_ = module_cpu_(input_)
+        gO = torch.rand_like(out_cpu_)
+        out_cpu_.backward(gO)
+        out_cuda_ = module_cuda_(input_cuda_)
+
+        gO = gO.to(device="cuda", dtype=dtype)
+        out_cuda_.backward(gO)
+        self.assertFalse(out_cpu_.is_cuda)
+        self.assertTrue(out_cuda_.is_cuda)
+        torch.testing.assert_close(
+            out_cpu_.to(device="cuda", dtype=dtype), out_cuda_, **fwd_thresholds)
+        torch.testing.assert_close(
+            input_.grad.to(device="cuda", dtype=dtype), input_cuda_.grad, **bwd_thresholds)
+
+    def _test_fused_rms_norm(
+        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
+        fwd_thresholds=dict(rtol=None, atol=None), bwd_thresholds=dict(rtol=None, atol=None)
+        ):
+
+        normalized_shape = [32, 16]
+
+        if not mixed_fused:
+            module_cpu_ = FusedRMSNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).cpu()
+            module_cuda_ = FusedRMSNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).to(device="cuda", dtype=dtype)
+        else:
+            assert elementwise_affine
+            module_cpu_ = MixedFusedRMSNorm(
+                normalized_shape=normalized_shape).cpu()
+            module_cuda_ = MixedFusedRMSNorm(
+                normalized_shape=normalized_shape).to(device="cuda", dtype=dtype)
+
+        torch.cuda.manual_seed(42)
+        if contiguous:
+            input_shape = [batch_size] + normalized_shape
+            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
+            input_cuda_ = input_.to(device="cuda", dtype=dtype).detach().requires_grad_(True)
+            self.assertTrue(input_.is_contiguous())
+            self.assertTrue(input_cuda_.is_contiguous())
+        else:
+            input_shape = [batch_size] + normalized_shape
+            input_shape = [batch_size * 3] + [normalized_shape[0] * 5, normalized_shape[1] * 3]
+            input_src_ = torch.randn(input_shape, device="cpu")
+            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
+            input_cuda_ = input_src_.to(device="cuda", dtype=dtype)[::3, ::5, ::3].detach().requires_grad_(True)
+            # make sure that tensors are NOT contiguous.
+            self.assertFalse(input_.is_contiguous())
+            self.assertFalse(input_cuda_.is_contiguous())
+        out_cpu_ = module_cpu_(input_)
+        gO = torch.rand_like(out_cpu_)
+        out_cpu_.backward(gO)
+        out_cuda_ = module_cuda_(input_cuda_)
+
+        torch.testing.assert_close(
+            out_cpu_.to(device="cuda", dtype=dtype), out_cuda_.clone().detach(), **fwd_thresholds)
+        gO = gO.to(device="cuda", dtype=dtype)
+        out_cuda_.backward(gO)
+        self.assertFalse(out_cpu_.is_cuda)
+        self.assertTrue(out_cuda_.is_cuda)
+        torch.testing.assert_close(
+            input_.grad.to(device="cuda", dtype=dtype), input_cuda_.grad, **bwd_thresholds)
+        if elementwise_affine:
+            torch.testing.assert_close(module_cpu_.weight.grad.to(device="cuda", dtype=dtype),
+                                          module_cuda_.weight.grad, **bwd_thresholds)
+
+    # layer norm tests
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,), (True, False)))
+    )
+    def test_layer_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,), (True, False)))
+    )
+    def test_layer_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
+
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,), (True, False)))
+    )
+    def test_layer_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.half,), (True, False)))
+    )
+    def test_layer_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
+                                fwd_thresholds=dict(rtol=1e-3, atol=1e-3), bwd_thresholds=dict(rtol=1e-3, atol=1e-3))
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,), (True, False)))
+    )
+    def test_layer_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient, 
+                                fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-3))
+
+    # rms norm tests
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,), (True, False)))
+    )
+    def test_rms_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
+
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,), (True, False)))
+    )
+    def test_rms_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
+                                bwd_thresholds=dict(rtol=2e-3, atol=2e-4))
+
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,), (True, False)))
+    )
+    def test_rms_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
+                                bwd_thresholds=dict(rtol=2e-3, atol=2e-4))
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.half,), (True, False)))
+    )
+    def test_rms_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
+                                bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3))
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,), (True, False)))
+    )
+    def test_rms_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient, 
+                                fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-2))
+
+    @common_utils.parametrize(
+        "dtype, elementwise_affine, memory_efficient",
+        list(product(autocast_dtypes, (True, False), (True, False)))
+    )
+    def test_autocast_fused_layer_norm(self, dtype, elementwise_affine, memory_efficient):
+        bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
+        bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
+        batch_size = 16
+        normalized_shape = [32, 16]
+        native = torch.nn.LayerNorm(
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
+        ).to(device="cuda", dtype=dtype)
+        fused = FusedLayerNorm(
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+        ).cuda()
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
         expected = native(native_x)
-        with torch.cuda.amp.autocast(dtype=dtype):
+        with torch.amp.autocast('cuda', dtype=dtype):
             actual = fused(fused_x)
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedLayerNorm.bf16_fwd_thresholds
-        torch.testing.assert_allclose(actual, expected, **tols)
+        tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_fwd_thresholds
+        # original tests used torch.testing.assert_allclose, which disables dtype checking by default. 
+        # link to issue here: https://github.com/pytorch/pytorch/issues/61844
+        torch.testing.assert_close(actual, expected, **tols, check_dtype=False) 
 
         g_native = torch.rand_like(expected)
         with torch.no_grad():
@@ -256,32 +236,35 @@ class TestAutocastFusedLayerNorm(unittest.TestCase):
         expected.backward(g_native)
         actual.backward(g_fused)
 
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedLayerNorm.bf16_bwd_thresholds
-        torch.testing.assert_allclose(native_x.grad, fused_x.grad, **tols)
-
-    def test_autocast(self):
-        for (dtype, elementwise_affine) in itertools.product(autocast_dtypes, (True, False)):
-            with self.subTest(f"{dtype}-{elementwise_affine}"):
-                self._run_test(dtype, elementwise_affine)
-
-@unittest.skip("Skipped on ROCm5.2 due to the failure of reproducing the issue locally. (Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!) Please refer to https://github.com/ROCmSoftwarePlatform/apex/pull/78")
-class TestAutocastFusedRMSNorm(unittest.TestCase):
-    bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def setUp(self):
-        self.batch_size = 16
-        self.normalized_shape = [32, 16]
-
-    def _run_test(self, dtype, elementwise_affine):
-        native, fused = _prep_rms_layers(self.normalized_shape, elementwise_affine, dtype)
-        native_x, fused_x = _prep_inputs(self.batch_size, self.normalized_shape, dtype)
+        if dtype != torch.half:
+            tols = bf16_bwd_thresholds
+        elif memory_efficient:
+            tols = {'rtol': 1e-3, 'atol': 1e-4}
+        else:
+            tols = {'rtol': None, 'atol': None}
+        torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
+    @common_utils.parametrize(
+        "dtype, elementwise_affine, memory_efficient",
+        list(product(autocast_dtypes, (True, False), (True, False)))
+    )
+    def test_autocast_fused_rms_norm(self, dtype, elementwise_affine, memory_efficient):
+        bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
+        bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
+        batch_size = 16
+        normalized_shape = [32, 16]
+        native = FusedRMSNorm(
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient, 
+        ).to(dtype=dtype)
+        fused = FusedRMSNorm(
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient, 
+        ).cuda()
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
         expected = native(native_x.cpu())
-        with torch.cuda.amp.autocast(dtype=dtype):
+        with torch.amp.autocast('cuda', dtype=dtype):
             actual = fused(fused_x)
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedRMSNorm.bf16_fwd_thresholds
-        torch.testing.assert_allclose(actual, expected.detach().clone().cuda(), **tols)
+        tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_fwd_thresholds
+        torch.testing.assert_close(actual, expected.detach().clone().cuda(), **tols, check_dtype=False)
 
         g_native = torch.rand_like(expected)
         with torch.no_grad():
@@ -289,10 +272,100 @@ class TestAutocastFusedRMSNorm(unittest.TestCase):
         expected.backward(g_native)
         actual.backward(g_fused)
 
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedRMSNorm.bf16_bwd_thresholds
-        torch.testing.assert_allclose(native_x.grad.cuda(), fused_x.grad, **tols)
+        tols = {'rtol': 1e-3, 'atol': 1e-3} if dtype == torch.half else bf16_bwd_thresholds
+        torch.testing.assert_close(native_x.grad.cuda(), fused_x.grad, **tols, check_dtype=False)
 
-    def test_autocast(self):
-        for (dtype, elementwise_affine) in itertools.product(autocast_dtypes, (True, False)):
-            with self.subTest(f"{dtype}-{elementwise_affine}"):
-                self._run_test(dtype, elementwise_affine)
+    def _verify_export(self, fused, fused_x):
+        # check that export() is working
+        import io
+        f = io.BytesIO()
+        torch.onnx.export(fused, (fused_x,), f,
+                                 input_names=['x_in'],
+                                 opset_version=18,
+        )
+        # Load the ONNX model
+        import onnx
+        model_onnx = onnx.load_from_string(f.getvalue())
+        # Get string representation
+        onnx_str = onnx.helper.printable_graph(model_onnx.graph)
+
+        assert 'x_in' in onnx_str
+        assert 'ReduceMean' in onnx_str or 'LayerNormalization' in onnx_str
+
+    def test_rms_export(self):
+        batch_size = 16
+        normalized_shape = [32, 16]
+        fused = FusedRMSNorm(
+            normalized_shape=normalized_shape, elementwise_affine=True
+        ).cuda()
+        fused_m = MixedFusedRMSNorm(
+            normalized_shape=normalized_shape
+        ).cuda()
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
+        self._verify_export(fused, fused_x)
+        self._verify_export(fused_m, fused_x)
+        
+    def test_layer_norm_export(self):
+        batch_size = 16
+        normalized_shape = [32, 16]
+        fused = FusedLayerNorm(
+            normalized_shape=normalized_shape, elementwise_affine=True
+        ).cuda()
+        fused_m = MixedFusedLayerNorm(
+            normalized_shape=normalized_shape
+        ).cuda()
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
+        self._verify_export(fused, fused_x)
+        self._verify_export(fused_m, fused_x)
+
+    @common_utils.parametrize("elementwise_affine", (True, False))
+    def test_compile_fused_layer_norm(self, elementwise_affine):
+        batch_size = 16
+        normalized_shape = [32, 16]
+        eager_mod = FusedLayerNorm(
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
+        ).cuda()
+        compiled_mod = torch.compile(fullgraph=True)(eager_mod)
+        input_shape = [batch_size] + normalized_shape
+        eager_x = torch.randn(input_shape, device="cuda").requires_grad_(True)
+        compiled_x = eager_x.detach().clone().requires_grad_(True)
+
+        expected = eager_mod(eager_x)
+        actual = compiled_mod(compiled_x)
+        torch.testing.assert_close(actual, expected.detach())
+
+        g_eager = torch.rand_like(expected)
+        with torch.no_grad():
+            g_compiled = g_eager.detach().clone()
+        expected.backward(g_eager)
+        actual.backward(g_compiled)
+
+        torch.testing.assert_close(eager_x.grad, compiled_x.grad)
+
+    @common_utils.parametrize("elementwise_affine", (True, False))
+    def test_compile_fused_rms_norm(self, elementwise_affine):
+        batch_size = 16
+        normalized_shape = [32, 16]
+        eager_mod = FusedRMSNorm(
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
+        ).cuda()
+        compiled_mod = torch.compile(fullgraph=True)(eager_mod)
+        input_shape = [batch_size] + normalized_shape
+        eager_x = torch.randn(input_shape, device="cuda").requires_grad_(True)
+        compiled_x = eager_x.detach().clone().requires_grad_(True)
+
+        expected = eager_mod(eager_x)
+        actual = compiled_mod(compiled_x)
+        torch.testing.assert_close(actual, expected.detach())
+
+        g_eager = torch.rand_like(expected)
+        with torch.no_grad():
+            g_compiled = g_eager.detach().clone()
+        expected.backward(g_eager)
+        actual.backward(g_compiled)
+
+        torch.testing.assert_close(eager_x.grad, compiled_x.grad)
+        
+instantiate_device_type_tests(TestFusedLayerNorm, globals(), only_for=("cuda",))
+if __name__ == "__main__":
+    common_utils.run_tests()


### PR DESCRIPTION
The intra-warp reductions code inside cuWelfordMuSigma2() function in layer norm kernel assumes a warp size of 32, so added a condition for rocm to support gpu warp size (based on earlier apex code). For rocm, adjust the threadsize, based on earlier apex code.

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-484456