### PR TITLE
Fix unit tests for transformer, fused dense, mlp (#218)

### DIFF
--- a/apex/amp/_process_optimizer.py
+++ b/apex/amp/_process_optimizer.py
@@ -341,7 +341,7 @@ def _process_optimizer(optimizer, properties):
         import amp_C
         optimizer._amp_stash.multi_tensor_scale = amp_C.multi_tensor_scale
         optimizer._amp_stash.multi_tensor_l2norm = amp_C.multi_tensor_l2norm
-        optimizer._amp_stash.dummy_overflow_buf = torch.cuda.IntTensor([0]);
+        optimizer._amp_stash.dummy_overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
 
     if properties.master_weights:
         optimizer._lazy_init_maybe_master_weights = types.MethodType(

--- a/apex/amp/scaler.py
+++ b/apex/amp/scaler.py
@@ -62,7 +62,7 @@ class LossScaler(object):
         self._scale_seq_len = scale_window
         self._unskipped = 0
         self._has_overflow = False
-        self._overflow_buf = torch.cuda.IntTensor([0])
+        self._overflow_buf = torch.tensor([0], dtype=torch.int, device='cuda')
         if multi_tensor_applier.available:
             import amp_C
             LossScaler.has_fused_kernel = multi_tensor_applier.available

--- a/apex/fused_dense/fused_dense.py
+++ b/apex/fused_dense/fused_dense.py
@@ -124,11 +124,11 @@ class FusedDenseGeluDense(nn.Module):
         self.in_features = in_features
         self.intermediate_features = intermediate_features
         self.out_features = out_features
-        self.weight = nn.Parameter(torch.randn(intermediate_features, in_features))
-        self.bias = nn.Parameter(torch.randn(intermediate_features))
+        self.weight1 = nn.Parameter(torch.randn(intermediate_features, in_features))
+        self.bias1 = nn.Parameter(torch.randn(intermediate_features))
         self.weight2 = nn.Parameter(torch.randn(out_features, intermediate_features))
         self.bias2 = nn.Parameter(torch.randn(out_features))
 
     def forward(self, input):
-        return fused_dense_gelu_dense_function(input, self.weight, self.bias, self.weight2, self.bias2)
+        return fused_dense_gelu_dense_function(input, self.weight1, self.bias1, self.weight2, self.bias2)
 

--- a/tests/L0/run_amp/test_add_param_group.py
+++ b/tests/L0/run_amp/test_add_param_group.py
@@ -154,6 +154,8 @@ class TestAddParamGroup(unittest.TestCase):
                                       "opt_level = {}, how_to_zero = {}, zero_before_add = {}".format(
                                       opt_level, how_to_zero, zero_before_add))
 
+                  if opt_level != "O0":
+                    _amp_state.handle._deactivate()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/L0/run_amp/test_fused_sgd.py
+++ b/tests/L0/run_amp/test_fused_sgd.py
@@ -180,7 +180,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                             self.assertTrue(torch.allclose(model, reference))
                             self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                        if opt_level == "O1":
+                        if opt_level != "O0":
                             _amp_state.handle._deactivate()
 
     @unittest.skipIf(disabled, "amp_C is unavailable")
@@ -341,7 +341,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                               self.assertTrue(torch.allclose(model, reference))
                               self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                          if opt_level == "O1":
+                          if opt_level != "O0":
                               _amp_state.handle._deactivate()
 
     @unittest.skipIf(disabled, "amp_C is unavailable")
@@ -536,7 +536,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                             self.assertTrue(torch.allclose(model, reference))
                             self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                        if opt_level == "O1":
+                        if opt_level != "O0":
                             _amp_state.handle._deactivate()
 
     @unittest.skipIf(disabled, "amp_C is unavailable")
@@ -786,7 +786,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                               self.assertTrue(torch.allclose(model, reference))
                               self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                          if opt_level == "O1":
+                          if opt_level != "O0":
                               _amp_state.handle._deactivate()
 
 if __name__ == '__main__':

--- a/tests/L0/run_amp/test_larc.py
+++ b/tests/L0/run_amp/test_larc.py
@@ -7,6 +7,7 @@ from torch.nn import Parameter
 from apex import amp
 from apex.parallel.LARC import LARC
 from utils import common_init
+from apex.amp import _amp_state
 
 
 class MyModel(torch.nn.Module):
@@ -47,6 +48,10 @@ class TestLARC(unittest.TestCase):
             with amp.scale_loss(loss, optimizer) as scaled_loss:
                 scaled_loss.backward()
             optimizer.step()
+
+            if opt_level != "O0":
+                _amp_state.handle._deactivate()
+
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_amp/test_multi_tensor_axpby.py
+++ b/tests/L0/run_amp/test_multi_tensor_axpby.py
@@ -35,7 +35,7 @@ class TestMultiTensorAxpby(unittest.TestCase):
         self.b = 8.0
         self.xval = 4.0
         self.yval = 16.0
-        self.overflow_buf = torch.cuda.IntTensor(1).zero_()
+        self.overflow_buf = torch.tensor(1, dtype=torch.int, device='cuda').zero_()
         self.ref = torch.full((1,), 136.0, device="cuda", dtype=torch.float32)
 
     def tearDown(self):

--- a/tests/L0/run_amp/test_multi_tensor_l2norm.py
+++ b/tests/L0/run_amp/test_multi_tensor_l2norm.py
@@ -26,7 +26,7 @@ class TestMultiTensorL2Norm(unittest.TestCase):
     def setUp(self):
         common_init(self)
         self.val = 4.0
-        self.overflow_buf = torch.cuda.IntTensor(1).zero_()
+        self.overflow_buf = torch.tensor(1, dtype=torch.int, device='cuda').zero_()
 
     def tearDown(self):
         pass

--- a/tests/L0/run_amp/test_multi_tensor_scale.py
+++ b/tests/L0/run_amp/test_multi_tensor_scale.py
@@ -26,7 +26,7 @@ class TestMultiTensorScale(unittest.TestCase):
     def setUp(self):
         common_init(self)
         self.scale = 4.0
-        self.overflow_buf = torch.cuda.IntTensor(1).zero_()
+        self.overflow_buf = torch.tensor(1, dtype=torch.int, device='cuda').zero_()
         self.ref = torch.cuda.FloatTensor([1.0])
 
     def tearDown(self):

--- a/tests/L0/run_amp/test_multiple_models_optimizers_losses.py
+++ b/tests/L0/run_amp/test_multiple_models_optimizers_losses.py
@@ -164,7 +164,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                           self.assertTrue(torch.allclose(model, reference))
                           self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                      if opt_level == "O1":
+                      if opt_level != "O0":
                           _amp_state.handle._deactivate()
 
     def test_3models2losses1optimizer(self):
@@ -320,7 +320,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                             self.assertTrue(torch.allclose(model, reference))
                             self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                        if opt_level == "O1":
+                        if opt_level != "O0":
                             _amp_state.handle._deactivate()
 
     def test_2models2losses2optimizers(self):
@@ -510,7 +510,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                           self.assertTrue(torch.allclose(model, reference))
                           self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                      if opt_level == "O1":
+                      if opt_level != "O0":
                           _amp_state.handle._deactivate()
 
     def test_3models2losses2optimizers(self):
@@ -755,7 +755,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                             self.assertTrue(torch.allclose(model, reference))
                             self.assertTrue(torch.allclose(model, master.to(model.dtype)))
 
-                        if opt_level == "O1":
+                        if opt_level != "O0":
                             _amp_state.handle._deactivate()
 
 if __name__ == '__main__':

--- a/tests/L0/run_amp/utils.py
+++ b/tests/L0/run_amp/utils.py
@@ -24,4 +24,5 @@ def common_init(test_case):
     test_case.c = 16
     test_case.k = 3
     test_case.t = 10
-    torch.set_default_tensor_type(torch.cuda.FloatTensor)
+    torch.set_default_device('cuda')
+    torch.set_default_dtype(torch.float)

--- a/tests/L0/run_mlp/test_mlp.py
+++ b/tests/L0/run_mlp/test_mlp.py
@@ -39,7 +39,7 @@ class TestMLP(unittest.TestCase):
         np.testing.assert_allclose(
             mlp_out.detach().cpu().numpy(),
             ref_out.detach().cpu().numpy(),
-            atol=1e-7, rtol=1e-5)
+            atol=1e-5, rtol=1e-5)
 
         # Use mean value as scalar loss. Multiply 10 to make it big enough not zero out
         mlp_out.mean().mul(10.).backward()
@@ -47,11 +47,11 @@ class TestMLP(unittest.TestCase):
         np.testing.assert_allclose(
             test_input.grad.detach().cpu().numpy(),
             ref_input.grad.detach().cpu().numpy(),
-            atol=0, rtol=1e-5)
+            atol=1e-5, rtol=1e-5)
         np.testing.assert_allclose(
             mlp.biases[0].grad.detach().cpu().numpy(),
             ref_mlp[0].bias.grad.detach().cpu().numpy(),
-            atol=1e-7, rtol=1e-5)
+            atol=1e-5, rtol=1e-5)
 
     @skipFlakyTest
     def test_no_bias(self):
@@ -77,7 +77,7 @@ class TestMLP(unittest.TestCase):
             np.testing.assert_allclose(
                 mlp_out.detach().cpu().numpy(),
                 ref_out.detach().cpu().numpy(),
-                atol=1e-7, rtol=1e-5)
+                atol=1e-5, rtol=1e-5)
 
             # Use mean value as scalar loss. Multiply 10 to make it big enough not zero out
             mlp_out.mean().mul(10.).backward()
@@ -85,11 +85,11 @@ class TestMLP(unittest.TestCase):
             np.testing.assert_allclose(
                 test_input.grad.detach().cpu().numpy(),
                 ref_input.grad.detach().cpu().numpy(),
-                atol=0, rtol=100)
+                atol=1e-5, rtol=100)
             np.testing.assert_allclose(
                 mlp.weights[0].grad.detach().cpu().numpy(),
                 ref_mlp[0].weight.grad.detach().cpu().numpy(),
-                atol=1e-7, rtol=100)
+                atol=1e-5, rtol=100)
 
     @skipFlakyTest
     def test_with_bias(self):
@@ -116,7 +116,7 @@ class TestMLP(unittest.TestCase):
             np.testing.assert_allclose(
                 mlp_out.detach().cpu().numpy(),
                 ref_out.detach().cpu().numpy(),
-                atol=1e-7, rtol=1e-5)
+                atol=1e-5, rtol=1e-5)
 
             # Use mean value as scalar loss. Multiply 10 to make it big enough not zero out
             mlp_out.mean().mul(10.).backward()
@@ -124,15 +124,15 @@ class TestMLP(unittest.TestCase):
             np.testing.assert_allclose(
                 test_input.grad.detach().cpu().numpy(),
                 ref_input.grad.detach().cpu().numpy(),
-                atol=0, rtol=1)
+                atol=1e-5, rtol=1)
             np.testing.assert_allclose(
                 mlp.weights[0].grad.detach().cpu().numpy(),
                 ref_mlp[0].weight.grad.detach().cpu().numpy(),
-                atol=1e-7, rtol=1)
+                atol=1e-5, rtol=1)
             np.testing.assert_allclose(
                 mlp.biases[0].grad.detach().cpu().numpy(),
                 ref_mlp[0].bias.grad.detach().cpu().numpy(),
-                atol=1e-7, rtol=1e-5)
+                atol=1e-5, rtol=1e-5)
 
     @skipFlakyTest
     def test_no_grad(self):
@@ -155,7 +155,7 @@ class TestMLP(unittest.TestCase):
         np.testing.assert_allclose(
             mlp_out.detach().cpu().numpy(),
             ref_out.detach().cpu().numpy(),
-            atol=1e-7, rtol=1e-5)
+            atol=1e-5, rtol=1e-5)
 
         # Use mean value as scalar loss. Multiply 10 to make it big enough not zero out
         mlp_out.mean().mul(10.).backward()
@@ -163,7 +163,7 @@ class TestMLP(unittest.TestCase):
         np.testing.assert_allclose(
             mlp.weights[0].grad.detach().cpu().numpy(),
             ref_mlp[0].weight.grad.detach().cpu().numpy(),
-            atol=1e-7, rtol=1e-5)
+            atol=1e-5, rtol=1e-5)
 
     def test_performance_half(self):
         mlp = MLP(mlp_sizes).cuda().half()

--- a/tests/L0/run_transformer/test_batch_sampler.py
+++ b/tests/L0/run_transformer/test_batch_sampler.py
@@ -7,6 +7,9 @@ from torch.utils.data import RandomSampler
 from torch.utils.data import BatchSampler
 from torch.utils.data import DataLoader
 
+#reset the default device to cpu so that the generator, as run_amp tests set its to cuda
+torch.set_default_device('cpu')
+
 from apex.transformer.pipeline_parallel.utils import _split_batch_into_microbatch as split_batch_into_microbatch
 
 


### PR DESCRIPTION
Fused dense and transformer unit pass when running individually.
But fail when amp unit test are run before these.

- Fix fused dense gelu dense by correcting the name of the parameters so that they match the unit test.
- The majority of the unit test failures in transformer and fused dense were caused by not deactivating amp_state handle. So added amp_state deactivation code to run_amp unit tests. 
- The tolerances for mlp unit tests were too low(either 0 or 1e-7). 
- The transformer unit test used cuda as torch default device (due to run_amp) so it had to be explicitly reset to cpu so that the generator for data loader would use cuda.
- Reduced warnings by updating method for setting device, tensor dtype and overflow buffer creation.
