### PR TITLE
[master] Added AITER as a submodule and use in fused_rope.py 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "apex/contrib/csrc/cudnn-frontend"]
 	path = apex/contrib/csrc/cudnn-frontend
 	url = https://github.com/NVIDIA/cudnn-frontend.git
+[submodule "third_party/aiter"]
+	path = third_party/aiter
+	url = https://github.com/ROCm/aiter

--- a/apex/transformer/functional/fused_rope.py
+++ b/apex/transformer/functional/fused_rope.py
@@ -16,6 +16,7 @@ from typing import Tuple, Union
 import torch
 import os
 from torch.utils.cpp_extension import ROCM_HOME
+import warnings
 
 TORCH_MAJOR = int(torch.__version__.split('.')[0])
 TORCH_MINOR = int(torch.__version__.split('.')[1])
@@ -45,12 +46,12 @@ if IS_ROCM_PYTORCH and USE_ROCM_AITER_ROPE_BACKEND:
     try:
         import aiter
         AITER_ROPE_BACKEND = True
-        print("Aiter backend is selected for fused RoPE. This has lower precision. To disable aiter, export AITER_ROPE_BACKEND_ENABLE=0")
+        warnings.warn("Aiter backend is selected for fused RoPE. This has lower precision. To disable aiter, export AITER_ROPE_BACKEND_ENABLE=0", UserWarning)
     except ImportError:
         AITER_ROPE_BACKEND = False
 if not AITER_ROPE_BACKEND:
     import fused_rotary_positional_embedding
-    print("Using the native apex kernel for RoPE.")
+    warnings.warn("Using the native apex kernel for RoPE.", UserWarning)
 
 
 class FusedRoPEFunc(torch.autograd.Function):

--- a/apex/transformer/functional/fused_rope.py
+++ b/apex/transformer/functional/fused_rope.py
@@ -174,10 +174,8 @@ def fused_apply_rotary_pos_emb(
     Returns:
         Tensor: The input tensor after applying RoPE
     """
-    if not AITER_ROPE_BACKEND:
-        return FusedRoPEFuncApex.apply(t, freqs, transpose_output_memory)
-    else:
-        return FusedRoPEFuncAiter.apply(t, freqs, transpose_output_memory)
+    FusedRoPEFunc = FusedRoPEFuncAiter if AITER_ROPE_BACKEND else FusedRoPEFuncApex
+    return FusedRoPEFunc.apply(t, freqs, transpose_output_memory)
 
 class FusedRoPECachedFunc(torch.autograd.Function):
     """
@@ -303,10 +301,8 @@ def fused_apply_rotary_pos_emb_cached(
     Returns:
         Tensor: The input tensor after applying RoPE
     """
-    if not AITER_ROPE_BACKEND:
-        return FusedRoPECachedFuncApex.apply(t, cos_, sin_, transpose_output_memory)
-    else:
-        return FusedRoPECachedFuncAiter.apply(t, cos_, sin_, transpose_output_memory)
+    FusedRoPEFunc = FusedRoPECachedFuncAiter if AITER_ROPE_BACKEND else FusedRoPECachedFuncApex
+    return FusedRoPEFunc.apply(t, cos_, sin_, transpose_output_memory)
 
 class FusedRoPETHDFunc(torch.autograd.Function):
     """
@@ -414,11 +410,8 @@ def fused_apply_rotary_pos_emb_thd(
     Returns:
         Tensor: The input tensor after applying RoPE
     """
-    if not AITER_ROPE_BACKEND:
-        return FusedRoPETHDFuncApex.apply(t, cu_seqlens, freqs)
-    else:
-        return FusedRoPETHDFuncAiter.apply(t, cu_seqlens, freqs)
-
+    FusedRoPEFunc = FusedRoPETHDFuncAiter if AITER_ROPE_BACKEND else FusedRoPETHDFuncApex
+    return FusedRoPEFunc.apply(t, cu_seqlens, freqs)
 
 class FusedRoPE2DFunc(torch.autograd.Function):
     """
@@ -568,7 +561,5 @@ def fused_apply_rotary_pos_emb_2d(
     assert (
         cos_w.size() == sin_w.size()
     ), "The shape of cos_w and sin_w should be the same"
-    if not AITER_ROPE_BACKEND:
-        return FusedRoPE2DFuncApex.apply(t, img_h, img_w, cos_h, sin_h, cos_w, sin_w)
-    else:
-        return FusedRoPE2DFuncAiter.apply(t, img_h, img_w, cos_h, sin_h, cos_w, sin_w)
+    FusedRoPEFunc = FusedRoPE2DFuncAiter if AITER_ROPE_BACKEND else FusedRoPE2DFuncApex
+    return FusedRoPEFunc.apply(t, img_h, img_w, cos_h, sin_h, cos_w, sin_w)

--- a/apex/transformer/functional/fused_rope.py
+++ b/apex/transformer/functional/fused_rope.py
@@ -16,12 +16,23 @@ from typing import Tuple, Union
 import torch
 import os
 
+
+from torch.utils.cpp_extension import ROCM_HOME
+
 # a flag to switch between the native apex kernel and native aiter kernel
-AITER_ROPE_BACKEND = int(os.environ.get("AITER_ROPE_BACKEND", 0)) == 1
+AITER_ROPE_BACKEND = False
 '''
 False - native kernel in apex repo
 True - aiter native kernel
 '''
+
+#switch on aiter backend if it is rocm and aiter is installed
+if ROCM_HOME:
+    try:
+        import aiter
+        AITER_ROPE_BACKEND = True
+    except ImportError:
+        print("Aiter is not found, using the native apex kernel for RoPE. ")
 
 
 class FusedRoPEFunc(torch.autograd.Function):

--- a/apex/transformer/functional/fused_rope.py
+++ b/apex/transformer/functional/fused_rope.py
@@ -220,7 +220,7 @@ class FusedRoPECachedFuncApex(FusedRoPECachedFunc):
         ctx.transpose_output_memory = transpose_output_memory
 
         return output
-    
+
     @staticmethod
     def backward(
         ctx, grad_output: torch.Tensor

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML>=5.1
 pytest>=3.5.1
 packaging>=14.0
 matplotlib>=3.8
+pandas>=2.2.2

--- a/setup.py
+++ b/setup.py
@@ -523,8 +523,8 @@ if "--cuda_ext" in sys.argv:
         )
 
 #***********  fused_rotary_positional_embedding   ****************
-    if ROCM_HOME:
-        subprocess.run(["python3", "setup.py", "develop"], cwd = "third_party/aiter")
+    if IS_ROCM_PYTORCH:
+        subprocess.run(["pip", "install", "-e", "."], cwd = "third_party/aiter")
 
     ext_modules.append(
         CUDAExtension(

--- a/setup.py
+++ b/setup.py
@@ -524,7 +524,7 @@ if "--cuda_ext" in sys.argv:
 
 #***********  fused_rotary_positional_embedding   ****************
     if IS_ROCM_PYTORCH:
-        subprocess.run(["pip", "install", "-e", "."], cwd = "third_party/aiter")
+        subprocess.run(["pip", "install", "."], cwd = "third_party/aiter")
 
     ext_modules.append(
         CUDAExtension(

--- a/setup.py
+++ b/setup.py
@@ -523,6 +523,9 @@ if "--cuda_ext" in sys.argv:
         )
 
 #***********  fused_rotary_positional_embedding   ****************
+    if ROCM_HOME:
+        subprocess.run(["python3", "setup.py", "develop"], cwd = "third_party/aiter")
+
     ext_modules.append(
         CUDAExtension(
             name="fused_rotary_positional_embedding",

--- a/tests/L0/run_transformer/test_fused_rope.py
+++ b/tests/L0/run_transformer/test_fused_rope.py
@@ -13,7 +13,10 @@ from apex.transformer.functional import (
     fused_apply_rotary_pos_emb_thd,
     fused_apply_rotary_pos_emb_2d,
 )
-
+from apex.transformer.functional.fused_rope import AITER_ROPE_BACKEND
+ERROR_TOLERANCE=1e-3
+if AITER_ROPE_BACKEND:
+    ERROR_TOLERANCE=1e-2
 
 def _rotate_half(x: torch.Tensor) -> torch.Tensor:
     """Change sign so the last dimension becomes [-odd, +even]
@@ -183,16 +186,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {seq_length=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, {transpose_output_memory=}, loss_func={loss_func.__name__}",
-                atol=1e-2,
-                rtol=1e-2,
+                atol=ERROR_TOLERANCE,
+                rtol=ERROR_TOLERANCE,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {seq_length=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, {transpose_output_memory=}, loss_func={loss_func.__name__}",
-                atol=1e-2,
-                rtol=1e-2,
+                atol=ERROR_TOLERANCE,
+                rtol=ERROR_TOLERANCE,
             )
             assert (
                 output_fused.transpose(0, 1).is_contiguous() is transpose_output_memory
@@ -255,16 +258,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {cu_seqlens=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-2,
-                rtol=1e-2,
+                atol=ERROR_TOLERANCE,
+                rtol=ERROR_TOLERANCE,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {cu_seqlens=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-2,
-                rtol=1e-2,
+                atol=ERROR_TOLERANCE,
+                rtol=ERROR_TOLERANCE,
             )
 
     def test_2d_forward_backward(self):
@@ -331,16 +334,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {img_h=}, {img_w=}, {hidden_size=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-2,
-                rtol=1e-2,
+                atol=ERROR_TOLERANCE,
+                rtol=ERROR_TOLERANCE,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {img_h=}, {img_w=}, {hidden_size=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-2,
-                rtol=1e-2,
+                atol=ERROR_TOLERANCE,
+                rtol=ERROR_TOLERANCE,
             )
 
 

--- a/tests/L0/run_transformer/test_fused_rope.py
+++ b/tests/L0/run_transformer/test_fused_rope.py
@@ -183,16 +183,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {seq_length=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, {transpose_output_memory=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {seq_length=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, {transpose_output_memory=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             assert (
                 output_fused.transpose(0, 1).is_contiguous() is transpose_output_memory
@@ -255,16 +255,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {cu_seqlens=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {cu_seqlens=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
 
     def test_2d_forward_backward(self):
@@ -331,16 +331,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {img_h=}, {img_w=}, {hidden_size=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {img_h=}, {img_w=}, {hidden_size=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
 
 


### PR DESCRIPTION
Added AITER support in fused_rope.py for all 4 variants. Updated fused rope test, reduced tolerances according to unit test in aiter repo.
Tested UT -  python tests/L0/run_transformer/test_fused_rope.py

Added aiter as a submodule and build it in setup.py if it is rocm.

For rocm, it uses AITER backend
For cuda, it uses apex native kernels

Tested with 6.5_internal_testing and upstream main

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-496182