### PR TITLE
Added AITER as a submodule and use in fused_rope.py

### DIFF
--- a/tests/L0/run_transformer/test_fused_rope.py
+++ b/tests/L0/run_transformer/test_fused_rope.py
@@ -183,16 +183,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {seq_length=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, {transpose_output_memory=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {seq_length=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, {transpose_output_memory=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             assert (
                 output_fused.transpose(0, 1).is_contiguous() is transpose_output_memory
@@ -255,16 +255,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {cu_seqlens=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {cu_seqlens=}, {hidden_size=}, {rotary_percent=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
 
     def test_2d_forward_backward(self):
@@ -331,16 +331,16 @@ class TestFusedRoPE(common_utils.TestCase):
                 output_fused,
                 msg=f"{dtype=}, {img_h=}, {img_w=}, {hidden_size=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
             self.assertEqual(
                 grad_unfused,
                 grad_fused,
                 msg=f"{dtype=}, {img_h=}, {img_w=}, {hidden_size=}, "
                 f"{transpose=}, loss_func={loss_func.__name__}",
-                atol=1e-3,
-                rtol=1e-3,
+                atol=1e-2,
+                rtol=1e-2,
             )
 
 


### PR DESCRIPTION
Added AITER support in fused_rope.py for all 4 variants. Updated fused rope test, reduced tolerances according to unit test in aiter repo.
Tested UT - python tests/L0/run_transformer/test_fused_rope.py

Added aiter as a submodule and build it in setup.py if it is rocm.

For rocm, it uses AITER backend
For cuda, it uses apex native kernels

Tested with 6.5_internal_testing and upstream main

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-496182