### PR TITLE
Disabling Aiter Installation in default build

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ python setup.py install --cpp_ext --cuda_ext
 ```
 Note that using --cuda_ext flag to install Apex will also enable all the extensions supported on ROCm including "--distributed_adam", "--distributed_lamb", "--bnp", "--xentropy", "--deprecated_fused_adam", "--deprecated_fused_lamb", and "--fast_multihead_attn".
 
+In addition, aiter backend can be built during apex installation by providing --aiter flag
+```
+# if pip >= 23.1 (ref: https://pip.pypa.io/en/stable/news/#v23-1) which supports multiple `--config-settings` with the same key...
+pip install -v --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" --config-settings "--build-option=--aiter" ./
+# otherwise
+python setup.py install --cpp_ext --cuda_ext --aiter
+```
+
+To use aiter in fused rope, you can use the flag ```USE_ROCM_AITER_ROPE_BACKEND=1```.
+
 ### Enable hipblasLT on ROCm
 hipblasLT is supported only on mi300 (gfx942) only.  
 python setup.py automatically builds apex with hipblasLT support only if GPU device id is gfx942  

--- a/apex/transformer/functional/fused_rope.py
+++ b/apex/transformer/functional/fused_rope.py
@@ -46,7 +46,7 @@ if IS_ROCM_PYTORCH and USE_ROCM_AITER_ROPE_BACKEND:
     try:
         import aiter
         AITER_ROPE_BACKEND = True
-        warnings.warn("Aiter backend is selected for fused RoPE. This has lower precision. To disable aiter, export AITER_ROPE_BACKEND_ENABLE=0", UserWarning)
+        warnings.warn("Aiter backend is selected for fused RoPE. This has lower precision. To disable aiter, export USE_ROCM_AITER_ROPE_BACKEND=0", UserWarning)
     except ImportError:
         AITER_ROPE_BACKEND = False
 if not AITER_ROPE_BACKEND:

--- a/setup.py
+++ b/setup.py
@@ -523,7 +523,8 @@ if "--cuda_ext" in sys.argv:
         )
 
 #***********  fused_rotary_positional_embedding   ****************
-    if IS_ROCM_PYTORCH:
+    if IS_ROCM_PYTORCH and "--aiter" in sys.argv:
+        sys.argv.remove("--aiter")
         subprocess.run(["pip", "install", "."], cwd = "third_party/aiter")
 
     ext_modules.append(


### PR DESCRIPTION
made a flag to switch on/off aiter compile using --aiter when installing apex

fixes https://ontrack-internal.amd.com/browse/SWDEV-542835 

Tested it on Docker image : 
registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16387_ubuntu22.04_py3.10_pytorch_lw_rocm7.0_internal_testing_c3f758e0

| Setup.py condition | Is aiter compiled? | Ut condition                  | Backend used | Ut status                        |
| ------------------ | ------------------ | ----------------------------- | ------------ | -------------------------------- |
| \--aiter           | yes                |                               | aiter        | Fail, expected due to llvm issue |
| \--aiter           | yes                | USE_ROCM_AITER_ROPE_BACKEND=0 | Native apex  | pass                             |
| \--aiter           | yes                | USE_ROCM_AITER_ROPE_BACKEND=1 | aiter        | Fail, expected due to llvm issue |
|                    | no                 |                               | Native apex  | pass                             |
|                    | no                 | USE_ROCM_AITER_ROPE_BACKEND=0 | Native apex  | pass                             |
|                    | no                 | USE_ROCM_AITER_ROPE_BACKEND=1 | Native apex  | pass                             |