### PR TITLE
Fix warp size

### DIFF
--- a/apex/contrib/csrc/groupbn/batch_norm.h
+++ b/apex/contrib/csrc/groupbn/batch_norm.h
@@ -36,7 +36,7 @@
 #include "nhwc_batch_norm_kernel.h"
 #include "cuda_utils.h"
 #include "c10/macros/Macros.h"
-
+#include <ATen/cuda/CUDAContext.h>
 
 #define VERBOSE_DEFAULT false
 
@@ -626,7 +626,7 @@ class NhwcBatchNorm {
   // Calculate the expected fwd kernel occupancy, as dictated by shared memory usage.
   static int smem_driven_fwd_occupancy(int device_id, const int max_cta_per_sm) {
     using namespace at::cuda::utils;
-    int fwd_reduction_bytes = THREADS_PER_PIXEL*(THREADS_PER_CTA/C10_WARP_SIZE)*ELEMENTS_PER_LDG*sizeof(float);
+    int fwd_reduction_bytes = THREADS_PER_PIXEL*(THREADS_PER_CTA/at::cuda::warp_size())*ELEMENTS_PER_LDG*sizeof(float);
     int fwd_smem_bytes = SMEM_SIZE_FWD + fwd_reduction_bytes;
     int occupancy = MaxSharedMemoryPerMultiprocessor(device_id) / fwd_smem_bytes;
     return std::min(max_cta_per_sm, occupancy);
@@ -635,7 +635,7 @@ class NhwcBatchNorm {
   // Calculate the expected bwd kernel occupancy, as dictated by shared memory usage.
   static int smem_driven_bwd_occupancy(int device_id, const int max_cta_per_sm) {
     using namespace at::cuda::utils;
-    int bwd_reduction_bytes = THREADS_PER_PIXEL*(THREADS_PER_CTA/C10_WARP_SIZE)*ELEMENTS_PER_LDG*sizeof(float);
+    int bwd_reduction_bytes = THREADS_PER_PIXEL*(THREADS_PER_CTA/at::cuda::warp_size())*ELEMENTS_PER_LDG*sizeof(float);
     int bwd_smem_bytes = SMEM_SIZE_BWD + bwd_reduction_bytes;
     int occupancy = MaxSharedMemoryPerMultiprocessor(device_id) / bwd_smem_bytes;
     return std::min(max_cta_per_sm, occupancy);

--- a/apex/contrib/csrc/multihead_attn/softmax.cuh
+++ b/apex/contrib/csrc/multihead_attn/softmax.cuh
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <cuda_fp16.h>
 #include <cmath>
+#include <ATen/cuda/CUDAContext.h>
  
 #ifdef USE_ROCM
 #define APEX_WARP_SHFL_XOR(mask, value, offset, width) __shfl_xor(value, offset, width)
@@ -1741,7 +1742,7 @@ void dispatch_masked_scale_softmax_backward_masked_out(
     // This value must match the WARP_SIZE constexpr value computed inside
     // softmax_warp_backward.
     int warp_size =
-        (next_power_of_two < C10_WARP_SIZE) ? next_power_of_two : C10_WARP_SIZE;
+        (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
     // This value must match the WARP_BATCH constexpr value computed inside
     // softmax_warp_backward.
@@ -1855,7 +1856,8 @@ void dispatch_masked_scale_softmax_backward_masked_out_stream(
     // This value must match the WARP_SIZE constexpr value computed inside
     // softmax_warp_backward.
     int warp_size =
-        (next_power_of_two < C10_WARP_SIZE) ? next_power_of_two : C10_WARP_SIZE;
+        (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
+
     // This value must match the WARP_BATCH constexpr value computed inside
     // softmax_warp_backward.
     int batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -2392,7 +2394,8 @@ void dispatch_masked_scale_softmax_backward_stream(
     // This value must match the WARP_SIZE constexpr value computed inside
     // softmax_warp_backward.
     int warp_size =
-        (next_power_of_two < C10_WARP_SIZE) ? next_power_of_two : C10_WARP_SIZE;
+        (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
+
     // This value must match the WARP_BATCH constexpr value computed inside
     // softmax_warp_backward.
     int batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -2593,7 +2596,7 @@ void dispatch_softmax_backward_fused_native(
     // This value must match the WARP_SIZE constexpr value computed inside
     // softmax_warp_backward.
     int warp_size =
-        (next_power_of_two < C10_WARP_SIZE) ? next_power_of_two : C10_WARP_SIZE;
+        (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
     // This value must match the WARP_BATCH constexpr value computed inside
     // softmax_warp_backward.

--- a/apex/contrib/csrc/multihead_attn/softmax.cuh
+++ b/apex/contrib/csrc/multihead_attn/softmax.cuh
@@ -236,7 +236,7 @@ bool warp_softmax_kernel(int log2_elements, int &warp_size,
                          softmax_forward_func<input_t, output_t> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -655,7 +655,7 @@ bool warp_additive_masked_softmax_dropout_kernel(
         &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -949,7 +949,7 @@ bool warp_additive_masked_softmax_kernel(
     additive_masked_softmax_forward_func<input_t, output_t> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -1241,7 +1241,7 @@ bool warp_masked_softmax_kernel(
     masked_softmax_forward_func<input_t, output_t> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -1489,7 +1489,7 @@ bool warp_time_masked_softmax_kernel(
     time_masked_softmax_forward_func<input_t, output_t> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -2256,7 +2256,7 @@ bool masked_scale_softmax_warp_backward_recompute_kernel(
                                                       is_log_softmax> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -2808,7 +2808,7 @@ bool warp_softmax_backward_kernel(
     softmax_backward_func<input_t, output_t> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;
@@ -3051,7 +3051,7 @@ bool warp_masked_softmax_backward_kernel(
     masked_softmax_backward_func<input_t, output_t> &kernel) {
   // determine size of a warp
   const int next_power_of_two = 1 << log2_elements;
-  warp_size = (next_power_of_two < 32) ? next_power_of_two : 32;
+  warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
   // determine how many batches a warp should process.
   batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;

--- a/csrc/megatron/fused_rotary_positional_embedding.h
+++ b/csrc/megatron/fused_rotary_positional_embedding.h
@@ -335,7 +335,7 @@ void dispatch_fused_rope_forward(const int s, const int b, const int h,
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(s, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_forward<<<blocks, threads, 0, stream>>>(
       h, d, d2, stride_s, stride_b, stride_h, stride_d, o_stride_s, o_stride_b,
@@ -356,7 +356,7 @@ void dispatch_fused_rope_backward(const int s, const int b, const int h,
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(s, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_backward<<<blocks, threads, 0, stream>>>(
       h, d, d2, stride_s, stride_b, stride_h, stride_d, o_stride_s, o_stride_b,
@@ -375,7 +375,7 @@ void dispatch_fused_rope_cached_forward(
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(s, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_cached_forward<<<blocks, threads, 0, stream>>>(
       h, d, d2, stride_s, stride_b, stride_h, stride_d, o_stride_s, o_stride_b,
@@ -394,7 +394,7 @@ void dispatch_fused_rope_cached_backward(
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(s, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_cached_backward<<<blocks, threads, 0, stream>>>(
       h, d, d2, stride_s, stride_b, stride_h, stride_d, o_stride_s, o_stride_b,
@@ -415,7 +415,7 @@ void dispatch_fused_rope_thd_forward(const int max_s, const int b, const int h,
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(max_s, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_thd_forward<<<blocks, threads, 0, stream>>>(
       h, d, d2, stride_t, stride_h, stride_d, o_stride_t, o_stride_h,
@@ -434,7 +434,7 @@ void dispatch_fused_rope_thd_backward(
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(max_s, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_thd_backward<<<blocks, threads, 0, stream>>>(
       h, d, d2, stride_t, stride_h, stride_d, o_stride_t, o_stride_h,
@@ -454,7 +454,7 @@ void dispatch_fused_rope_2d_forward(
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(ih, iw, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_2d_forward<<<blocks, threads, 0, stream>>>(
       ih, iw, h, d, stride_b, stride_ih, stride_iw, stride_h, stride_d,
@@ -476,7 +476,7 @@ void dispatch_fused_rope_2d_backward(
 
   int warps_per_block = h < 16 ? 4 : 8;
   dim3 blocks(ih, iw, b);
-  dim3 threads(C10_WARP_SIZE, warps_per_block);
+  dim3 threads(at::cuda::warp_size(), warps_per_block);
 
   fused_rope_2d_backward<<<blocks, threads, 0, stream>>>(
       ih, iw, h, d, stride_b, stride_ih, stride_iw, stride_h, stride_d,

--- a/csrc/megatron/generic_scaled_masked_softmax.h
+++ b/csrc/megatron/generic_scaled_masked_softmax.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <cuda_fp16.h>
 #include <c10/macros/Macros.h>
+#include <ATen/cuda/CUDAContext.h>
 
 namespace {
 
@@ -172,7 +173,7 @@ void dispatch_scaled_masked_softmax_backward_new(
         int batch_count = batches * attn_heads * query_seq_len;
         // use 128 threads per block to maximize gpu utilization
         constexpr int threads_per_block = 128;
-        int num_warps = (key_seq_len - 1) / C10_WARP_SIZE + 1;
+        int num_warps = (key_seq_len - 1) / at::cuda::warp_size() + 1;
         dim3 blocks(batch_count, 1, 1);
         dim3 threads(threads_per_block, 1, 1);
 
@@ -374,7 +375,7 @@ void dispatch_scaled_masked_softmax_forward_new(
         constexpr int threads_per_block = 128;
 
         // calculate the needed shared memory
-        int num_warps = (key_seq_len - 1) / C10_WARP_SIZE + 1;
+        int num_warps = (key_seq_len - 1) / at::cuda::warp_size() + 1;
 
         dim3 blocks(batch_count, 1, 1);
         dim3 threads(threads_per_block, 1, 1);

--- a/csrc/megatron/scaled_masked_softmax.h
+++ b/csrc/megatron/scaled_masked_softmax.h
@@ -663,7 +663,7 @@ void dispatch_scaled_masked_softmax_backward(
         int batch_count = batches *  attn_heads * query_seq_len;
 
         // This value must match the WARP_SIZE constexpr value computed inside softmax_warp_backward.
-        int warp_size = (next_power_of_two < C10_WARP_SIZE) ? next_power_of_two : C10_WARP_SIZE;
+        int warp_size = (next_power_of_two < at::cuda::warp_size()) ? next_power_of_two : at::cuda::warp_size();
 
         // This value must match the WARP_BATCH constexpr value computed inside softmax_warp_backward.
         int batches_per_warp = (next_power_of_two <= 128) ? 2 : 1;


### PR DESCRIPTION
Replace C10_WARP_SIZE, constant WARP_SIZE, constant THREADS_PER_WARP, warp.*32 regex uses with at::cuda::warp_size() when not used __device__ or __global__.

Tested with docker 
`registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16420_ubuntu22.04_py3.10_pytorch_lw_rocm7.0_internal_testing_2d567672`

Affected extensions:
1. fused rope - csrc/megatron/fused_rotary_positional_embedding.h
2. scaled_masked_softmax_cuda - , csrc/megatron/scaled_masked_softmax.h
3. generic_scaled_masked_softmax_cuda - csrc/megatron/generic_scaled_masked_softmax.h
4. scaled_upper_triang_masked_softmax_cuda - csrc/megatron/scaled_upper_triang_masked_softmax.h
5. group batch norm - apex/contrib/csrc/groupbn/batch_norm.h, apex/contrib/csrc/groupbn/batch_norm_add_relu.h
6. multihead attention - apex/contrib/csrc/multihead_attn/softmax.cuh
7. transducer - apex/contrib/csrc/transducer/transducer_joint_kernel.cu
8. xentropy - apex/contrib/csrc/xentropy/xentropy_kernel.cu
9. sync batch norm - csrc/welford.cu

The following UTs pass:

1. tests/L0/run_transformer/test_fused_rope.py
2. tests/L0/run_transformer/test_fused_softmax.py
3. apex/contrib/test/groupbn/test_groupbn.py
4. apex/contrib/test/groupbn/test_groupbn_channel_last.py
5. apex/contrib/test/multihead_attn/test_mha_fused_softmax.py
6. apex/contrib/test/transducer/test_transducer_joint.py
7. apex/contrib/test/transducer/test_transducer_loss.py
8. apex/contrib/test/test_label_smoothing.py
9. tests/distributed/synced_batchnorm/python_single_gpu_unit_test.py
10. tests/distributed/synced_batchnorm/single_gpu_unit_test.py
11. tests/distributed/synced_batchnorm/test_batchnorm1d.py
